### PR TITLE
Use single quote string if it contains double quotes

### DIFF
--- a/gem/lib/phlexing/converter.rb
+++ b/gem/lib/phlexing/converter.rb
@@ -42,7 +42,7 @@ module Phlexing
           @buffer << "text "
         end
 
-        @buffer << double_quote(text)
+        @buffer << quote(text)
         @buffer << "\n" if newline
       end
     end
@@ -99,7 +99,7 @@ module Phlexing
     def handle_comment_node(node, level)
       @buffer << indent(level)
       @buffer << "comment "
-      @buffer << double_quote(node.text.strip)
+      @buffer << quote(node.text.strip)
       @buffer << "\n"
     end
 

--- a/gem/lib/phlexing/helpers.rb
+++ b/gem/lib/phlexing/helpers.rb
@@ -16,6 +16,14 @@ module Phlexing
       "'#{string}'"
     end
 
+    def quote(string)
+      if string.include?('"')
+        single_quote(string)
+      else
+        double_quote(string)
+      end
+    end
+
     def node_name(node)
       return "template_tag" if node.name == "template"
       return node.name unless node.name.include?("-")

--- a/test/lib/phlexing/converter_test.rb
+++ b/test/lib/phlexing/converter_test.rb
@@ -60,6 +60,10 @@ module Phlexing
       assert_phlex %(div { "Text" }), %(<div>Text</div>)
     end
 
+    test "tag with one text node child with double quotes" do
+      assert_phlex %(div { 'Text with "quotes"' }), %(<div>Text with "quotes"</div>)
+    end
+
     test "tag with one text node child and long content" do
       expected = <<~HTML.strip
         div do
@@ -84,7 +88,7 @@ module Phlexing
       assert_phlex expected, %(<div class="app" id="body"><h1>Title 1</h1><h2>Title 2<span>Small Addition</span></h2></div>)
     end
 
-    test "tag with mulitple text and element children" do
+    test "tag with multiple text and element children" do
       expected = <<~HTML.strip
         div do
           text "Text"
@@ -338,6 +342,20 @@ module Phlexing
 
       html = <<~HTML.strip
         <!-- Hello World -->
+        <div>Hello World</div>
+      HTML
+
+      assert_phlex expected, html
+    end
+
+    test "HTML comment with double quotes" do
+      expected = <<~HTML.strip
+        comment 'Hello "World"'
+        div { "Hello World" }
+      HTML
+
+      html = <<~HTML.strip
+        <!-- Hello "World" -->
         <div>Hello World</div>
       HTML
 


### PR DESCRIPTION
I noticed that double quotes are not handled properly, this fixes that by using single quotes if the string contains any double quotes.

Before:
<img width="1278" alt="screenshot-2023-01-08-ffauQPpqleTHDJV9@2x" src="https://user-images.githubusercontent.com/170034/211186977-60462943-c979-42d4-ba0f-ec68ec15678b.png">

After:
<img width="1283" alt="screenshot-2023-01-08-njvRPIk3d3rP15xT@2x" src="https://user-images.githubusercontent.com/170034/211186988-fa8fb15b-321a-4ce5-bda3-1ab73448c2fe.png">
