### PR TITLE
Handle strings with single and double quotes

### DIFF
--- a/gem/lib/phlexing/helpers.rb
+++ b/gem/lib/phlexing/helpers.rb
@@ -16,12 +16,15 @@ module Phlexing
       "'#{string}'"
     end
 
+    def percent_literal_string(string)
+      "%(#{string})"
+    end
+
     def quote(string)
-      if string.include?('"')
-        single_quote(string)
-      else
-        double_quote(string)
-      end
+      return double_quote(string) unless string.include?('"')
+      return single_quote(string) unless string.include?("'")
+
+      percent_literal_string(string)
     end
 
     def node_name(node)

--- a/test/lib/phlexing/converter_test.rb
+++ b/test/lib/phlexing/converter_test.rb
@@ -60,8 +60,22 @@ module Phlexing
       assert_phlex %(div { "Text" }), %(<div>Text</div>)
     end
 
+    test "tag with one text node child with single quotes" do
+      assert_phlex %(div { "Text with 'single quotes'" }), %(<div>Text with 'single quotes'</div>)
+    end
+
     test "tag with one text node child with double quotes" do
-      assert_phlex %(div { 'Text with "quotes"' }), %(<div>Text with "quotes"</div>)
+      assert_phlex %(div { 'Text with "double quotes"' }), %(<div>Text with "double quotes"</div>)
+    end
+
+    test "tag with one text node child with single and double quotes" do
+      expected = <<~HTML.strip
+        div do
+          %(Text with 'single quotes' and "double quotes")
+        end
+      HTML
+
+      assert_phlex expected, %(<div>Text with 'single quotes' and "double quotes"</div>)
     end
 
     test "tag with one text node child and long content" do


### PR DESCRIPTION
In case we encounter a string with both single and double quotes, we can use a percent literal string to avoid escaping the quotes.

Before:
![image](https://user-images.githubusercontent.com/1100176/211289569-3838695a-71d8-43e5-8037-7ba85c999300.png)

After:
![image](https://user-images.githubusercontent.com/1100176/211289461-e930e095-8ec5-49e2-9a0b-a7609c2c3a1e.png)
