### PR TITLE
`raw` -> `unsafe_raw`

### DIFF
--- a/gem/lib/phlexing/converter.rb
+++ b/gem/lib/phlexing/converter.rb
@@ -55,7 +55,7 @@ module Phlexing
 
     def handle_erb_element(node, level, newline: true)
       if erb_safe_output?(node)
-        @buffer << "raw "
+        @buffer << "unsafe_raw "
         @buffer << node.text.from(1)
         @buffer << "\n" if newline
 

--- a/test/lib/phlexing/converter_test.rb
+++ b/test/lib/phlexing/converter_test.rb
@@ -249,7 +249,7 @@ module Phlexing
 
     test "ERB HTML safe output" do
       expected = <<~HTML.strip
-        div { raw "<p>Some safe HTML</p>" }
+        div { unsafe_raw "<p>Some safe HTML</p>" }
       HTML
 
       assert_phlex expected, %(<div><%== "<p>Some safe HTML</p>" %></div>)
@@ -258,7 +258,7 @@ module Phlexing
     test "ERB HTML safe output with siblings" do
       expected = <<~HTML.strip
         div do
-          raw "<p>Some safe HTML</p>"
+          unsafe_raw "<p>Some safe HTML</p>"
           text some_method
           span { "Text" }
         end
@@ -272,7 +272,7 @@ module Phlexing
     test "ERB HTML safe output and other erb output" do
       expected = <<~HTML.strip
         div do
-          raw "<p>Some safe HTML</p>"
+          unsafe_raw "<p>Some safe HTML</p>"
           text "Another output"
         end
       HTML


### PR DESCRIPTION
Phlex 1.0 renamed the `raw` method to `unsafe_raw`