### PR TITLE
Rely on `phlex` for known elements/custom elements

### DIFF
--- a/gem/lib/phlexing/helpers.rb
+++ b/gem/lib/phlexing/helpers.rb
@@ -1,7 +1,11 @@
 # frozen_string_literal: true
 
+require "phlex"
+
 module Phlexing
   module Helpers
+    KNOWN_ELEMENTS = Phlex::HTML::VOID_ELEMENTS.values + Phlex::HTML::STANDARD_ELEMENTS.values
+
     def indent(level)
       return "" if level == 1
 
@@ -33,10 +37,10 @@ module Phlexing
 
     def node_name(node)
       return "template_tag" if node.name == "template"
-      return node.name unless node.name.include?("-")
 
       name = node.name.gsub("-", "_")
-      @custom_elements << name
+
+      @custom_elements << name unless KNOWN_ELEMENTS.include?(name)
 
       name
     end

--- a/test/lib/phlexing/converter_test.rb
+++ b/test/lib/phlexing/converter_test.rb
@@ -16,17 +16,31 @@ module Phlexing
       assert_phlex %(br), %(<br />)
     end
 
-    test "basic custom element tag" do
-      html = %(<custom-element><custom-element>Custom Element</custom-element></custom-element>)
+    test "basic custom element tags" do
+      html = %(<c><d>Custom Element</d></c>)
 
       expected = <<~HTML.strip
-        custom_element do
-          custom_element { "Custom Element" }
+        c do
+          d { "Custom Element" }
         end
       HTML
 
       assert_phlex expected, html do
-        assert_custom_elements "custom_element"
+        assert_custom_elements "c", "d"
+      end
+    end
+
+    test "basic custom element tag with dashes" do
+      html = %(<custom-element-one><custom-element-two>Custom Element</custom-element-two></custom-element-one>)
+
+      expected = <<~HTML.strip
+        custom_element_one do
+          custom_element_two { "Custom Element" }
+        end
+      HTML
+
+      assert_phlex expected, html do
+        assert_custom_elements "custom_element_one", "custom_element_two"
       end
     end
 


### PR DESCRIPTION
This pull request changes the strategy for detecting custom elements. Previously it would just detect custom elements which had a dash in the tag name.

Now we rely on `Phlex::VOID_ELEMENTS` and `Phlex::STANARD_ELEMENTS` to detect if any given tag name is a regular or a custom element.