### PR TITLE
Sort and order attr, kwargs and custom elements

### DIFF
--- a/gem/lib/phlexing/converter.rb
+++ b/gem/lib/phlexing/converter.rb
@@ -184,11 +184,16 @@ module Phlexing
         if locals.any?
           buffer << indent(1)
           buffer << "attr_accessor "
-          buffer << @locals.map { |local| ":#{local}" }.join(", ")
+          buffer << locals.sort.map { |local| ":#{local}" }.join(", ")
           buffer << "\n\n"
         end
 
-        kwargs = Set.new(ivars + locals)
+        @custom_elements.sort.each do |element|
+          buffer << indent(1)
+          buffer << "register_element :#{element}\n"
+        end
+
+        kwargs = Set.new(ivars + locals).sort
 
         if kwargs.any?
           buffer << indent(1)
@@ -203,11 +208,6 @@ module Phlexing
 
           buffer << indent(1)
           buffer << "end\n"
-        end
-
-        @custom_elements.each do |element|
-          buffer << indent(1)
-          buffer << "register_element :#{element}\n"
         end
 
         buffer << indent(1)

--- a/test/lib/phlexing/converter_test.rb
+++ b/test/lib/phlexing/converter_test.rb
@@ -503,13 +503,41 @@ module Phlexing
 
       expected = <<~HTML.strip
         class Component < Phlex::HTML
-          register_element :my_custom
           register_element :another_custom
+          register_element :my_custom
 
           def template
             my_custom do
               text "Hello"
               another_custom { "World" }
+            end
+          end
+        end
+      HTML
+
+      assert_equal expected, Phlexing::Converter.new(html, phlex_class: true).output.strip
+    end
+
+    test "should generate phlex class with custom elements and attr_accessors in alphabetical order" do
+      html = %(<% users.each do |user| %><d><%= user.firstname %></d><c><%= abc %></c><% end %>)
+
+      expected = <<~HTML.strip
+        class Component < Phlex::HTML
+          attr_accessor :abc, :users
+
+          register_element :c
+          register_element :d
+
+          def initialize(abc:, users:)
+            @abc = abc
+            @users = users
+          end
+
+          def template
+            users.each do |user|
+              d { user.firstname }
+
+              c { abc }
             end
           end
         end
@@ -556,11 +584,11 @@ module Phlexing
         class Component < Phlex::HTML
           attr_accessor :show_company, :some_method
 
-          def initialize(user:, company:, show_company:, some_method:)
-            @user = user
+          def initialize(company:, show_company:, some_method:, user:)
             @company = company
             @show_company = show_company
             @some_method = some_method
+            @user = user
           end
 
           def template


### PR DESCRIPTION
This pull request changes how the converter generates the Phlex component. The order is now `attr_accessor`, `register_element` and then the `initialize()` method.

Additionally the `attr_accessor`, `register_elements`, `kwargs` and assignments in the `initialize()` are now alphabetically sorted.