### PR TITLE
Swap out `rufo` with `syntax_tree` for formatting

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -30,7 +30,6 @@ PATH
       html_press (~> 0.8.2)
       nokogiri (~> 1.0)
       phlex (~> 1.1)
-      rufo (~> 0.13.0)
       syntax_tree (~> 5.2)
 
 GEM
@@ -218,7 +217,6 @@ GEM
     rubocop-ast (1.21.0)
       parser (>= 3.1.1.0)
     ruby-progressbar (1.11.0)
-    rufo (0.13.0)
     sprockets (4.1.1)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)

--- a/gem/Gemfile.lock
+++ b/gem/Gemfile.lock
@@ -22,7 +22,6 @@ PATH
       html_press (~> 0.8.2)
       nokogiri (~> 1.0)
       phlex (~> 1.1)
-      rufo (~> 0.13.0)
       syntax_tree (~> 5.2)
 
 GEM
@@ -68,7 +67,6 @@ GEM
     rubocop-ast (1.24.1)
       parser (>= 3.1.1.0)
     ruby-progressbar (1.11.0)
-    rufo (0.13.0)
     syntax_tree (5.2.0)
       prettier_print (>= 1.2.0)
     treetop (1.6.12)

--- a/gem/lib/phlexing/component_generator.rb
+++ b/gem/lib/phlexing/component_generator.rb
@@ -34,6 +34,8 @@ module Phlexing
         out << "register_element :#{element}\n"
       end
 
+      out << "\n" if converter.custom_elements.any?
+
       if kwargs.any?
         out << indent(1)
         out << "def initialize("
@@ -46,7 +48,7 @@ module Phlexing
         end
 
         out << indent(1)
-        out << "end\n"
+        out << "end\n\n"
       end
 
       out << indent(1)

--- a/gem/lib/phlexing/formatter.rb
+++ b/gem/lib/phlexing/formatter.rb
@@ -1,12 +1,12 @@
 # frozen_string_literal: true
 
-require "rufo"
+require "syntax_tree"
 
 module Phlexing
   class Formatter
     def self.format(code)
-      Rufo::Formatter.format(code).strip
-    rescue Rufo::SyntaxError
+      SyntaxTree.format(code).strip
+    rescue SyntaxTree::Parser::ParseError
       code
     end
   end

--- a/gem/lib/phlexing/formatter.rb
+++ b/gem/lib/phlexing/formatter.rb
@@ -4,8 +4,8 @@ require "syntax_tree"
 
 module Phlexing
   class Formatter
-    def self.format(code)
-      SyntaxTree.format(code).strip
+    def self.format(code, max: 80)
+      SyntaxTree.format(code, max).strip
     rescue SyntaxTree::Parser::ParseError
       code
     end

--- a/gem/phlexing.gemspec
+++ b/gem/phlexing.gemspec
@@ -33,6 +33,5 @@ Gem::Specification.new do |spec|
   spec.add_dependency "html_press", "~> 0.8.2"
   spec.add_dependency "nokogiri", "~> 1.0"
   spec.add_dependency "phlex", "~> 1.1"
-  spec.add_dependency "rufo", "~> 0.13.0"
   spec.add_dependency "syntax_tree", "~> 5.2"
 end

--- a/gem/test/phlexing/converter/custom_elements_test.rb
+++ b/gem/test/phlexing/converter/custom_elements_test.rb
@@ -7,9 +7,7 @@ class Phlexing::Converter::CustomElementsTest < Minitest::Spec
     html = %(<c><d>Custom Element</d></c>)
 
     expected = <<~PHLEX.strip
-      c do
-        d { "Custom Element" }
-      end
+      c { d { "Custom Element" } }
     PHLEX
 
     assert_phlex_template expected, html do
@@ -21,9 +19,7 @@ class Phlexing::Converter::CustomElementsTest < Minitest::Spec
     html = %(<custom-element-one><custom-element-two>Custom Element</custom-element-two></custom-element-one>)
 
     expected = <<~PHLEX.strip
-      custom_element_one do
-        custom_element_two { "Custom Element" }
-      end
+      custom_element_one { custom_element_two { "Custom Element" } }
     PHLEX
 
     assert_phlex_template expected, html do
@@ -35,9 +31,7 @@ class Phlexing::Converter::CustomElementsTest < Minitest::Spec
     html = %(<first-element><second-element>Custom Element</second-element></first-element>)
 
     expected = <<~PHLEX.strip
-      first_element do
-        second_element { "Custom Element" }
-      end
+      first_element { second_element { "Custom Element" } }
     PHLEX
 
     assert_phlex_template expected, html do

--- a/gem/test/phlexing/converter/erb_test.rb
+++ b/gem/test/phlexing/converter/erb_test.rb
@@ -19,9 +19,7 @@ class Phlexing::Converter::ErbTest < Minitest::Spec
     html = %(<div><%= some_method_super_long_method_which_should_be_split_up %></div>)
 
     expected = <<~PHLEX.strip
-      div do
-        some_method_super_long_method_which_should_be_split_up
-      end
+      div { some_method_super_long_method_which_should_be_split_up }
     PHLEX
 
     assert_phlex_template expected, html do
@@ -64,9 +62,7 @@ class Phlexing::Converter::ErbTest < Minitest::Spec
     HTML
 
     expected = <<~PHLEX.strip
-      @articles.each do |article|
-        h1 { article.title }
-      end
+      @articles.each { |article| h1 { article.title } }
     PHLEX
 
     assert_phlex_template expected, html do
@@ -162,10 +158,11 @@ class Phlexing::Converter::ErbTest < Minitest::Spec
     HTML
 
     expected = <<~PHLEX.strip
-      @greeting = capture do
-        text " Welcome to my shiny new web page! The date and time is "
-        text Time.now
-      end
+      @greeting =
+        capture do
+          text " Welcome to my shiny new web page! The date and time is "
+          text Time.now
+        end
     PHLEX
 
     assert_phlex_template expected, html do

--- a/gem/test/phlexing/converter/erb_test.rb
+++ b/gem/test/phlexing/converter/erb_test.rb
@@ -16,14 +16,16 @@ class Phlexing::Converter::ErbTest < Minitest::Spec
   end
 
   it "ERB method call with long method name" do
-    html = %(<div><%= some_method_super_long_method_which_should_be_split_up %></div>)
+    html = %(<div><%= some_method_super_long_method_which_should_be_split_up_and_wrapped_in_a_block %></div>)
 
     expected = <<~PHLEX.strip
-      div { some_method_super_long_method_which_should_be_split_up }
+      div do
+        some_method_super_long_method_which_should_be_split_up_and_wrapped_in_a_block
+      end
     PHLEX
 
     assert_phlex_template expected, html do
-      assert_locals "some_method_super_long_method_which_should_be_split_up"
+      assert_locals "some_method_super_long_method_which_should_be_split_up_and_wrapped_in_a_block"
     end
   end
 

--- a/gem/test/phlexing/converter/tags_test.rb
+++ b/gem/test/phlexing/converter/tags_test.rb
@@ -50,10 +50,12 @@ class Phlexing::Converter::CustomElementsTest < Minitest::Spec
   end
 
   it "tag with one text node child and long content" do
-    html = %(<div>This is a super long text which exceeds the single line block limit</div>)
+    html = %(<div>This is a super long text which exceeds the single line block limit and therefore is wrapped in a block</div>)
 
     expected = <<~PHLEX.strip
-      div { "This is a super long text which exceeds the single line block limit" }
+      div do
+        "This is a super long text which exceeds the single line block limit and therefore is wrapped in a block"
+      end
     PHLEX
 
     assert_phlex_template expected, html

--- a/gem/test/phlexing/converter/tags_test.rb
+++ b/gem/test/phlexing/converter/tags_test.rb
@@ -43,9 +43,7 @@ class Phlexing::Converter::CustomElementsTest < Minitest::Spec
     html = %(<div>Text with 'single quotes' and "double quotes"</div>)
 
     expected = <<~PHLEX.strip
-      div do
-        %(Text with 'single quotes' and "double quotes")
-      end
+      div { %(Text with 'single quotes' and "double quotes") }
     PHLEX
 
     assert_phlex_template expected, html
@@ -55,9 +53,7 @@ class Phlexing::Converter::CustomElementsTest < Minitest::Spec
     html = %(<div>This is a super long text which exceeds the single line block limit</div>)
 
     expected = <<~PHLEX.strip
-      div do
-        "This is a super long text which exceeds the single line block limit"
-      end
+      div { "This is a super long text which exceeds the single line block limit" }
     PHLEX
 
     assert_phlex_template expected, html
@@ -123,9 +119,7 @@ class Phlexing::Converter::CustomElementsTest < Minitest::Spec
     html = %(<div><span></span></div>)
 
     expected = <<~PHLEX.strip
-      div do
-        span
-      end
+      div { span }
     PHLEX
 
     assert_phlex_template expected, html


### PR DESCRIPTION
This pull request swaps out `rufo` with `syntax_tree` for formatting the generated Ruby code.

Additionally, SyntaxTree automatically transforms wrapping parens, blocks, quotes and other things depending on the context. This can simplify the code generation logic on our end, because we can just let SyntaxTree handle it for us.