### PR TITLE
Primitive Rails Helpers support

### DIFF
--- a/gem/lib/phlexing/helpers.rb
+++ b/gem/lib/phlexing/helpers.rb
@@ -57,6 +57,36 @@ module Phlexing
       out << newline
     end
 
+    def blocklist
+      [
+        "render",
+        "tag",
+        "form_with",
+        "link_to"
+      ]
+    end
+
+    def regex_filter
+      [
+        /\w+_field/,
+        /\w+_tag/,
+        /\w+_select/,
+        /\w+_for/,
+        /select_\w+/
+      ]
+    end
+
+    def string_output?(node)
+      word = node.text.strip.scan(/^\w+/)[0]
+
+      return true if word.nil?
+
+      blocklist_matched = blocklist.include?(word)
+      filter_matched = regex_filter.map { |regex| word.scan(regex).any? }.reduce(:|)
+
+      !(blocklist_matched || filter_matched)
+    end
+
     def multiple_children?(node)
       node.children.length > 1
     end

--- a/gem/lib/phlexing/template_generator.rb
+++ b/gem/lib/phlexing/template_generator.rb
@@ -66,7 +66,7 @@ module Phlexing
     end
 
     def handle_erb_safe_node(node)
-      if multiple_children?(node.parent) && !node.text.strip.start_with?("render")
+      if multiple_children?(node.parent) && string_output?(node)
         handle_text_output(node.text.strip)
       else
         handle_output(node.text.strip)

--- a/gem/test/phlexing/converter/blocks_test.rb
+++ b/gem/test/phlexing/converter/blocks_test.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+require_relative "../../test_helper"
+
+class Phlexing::Converter::BlocksTest < Minitest::Spec
+  it "empty block" do
+    html = %(<%= tag.div do %><% end %>)
+
+    expected = <<~PHLEX.strip
+      tag.div {}
+    PHLEX
+
+    assert_phlex_template expected, html do
+      assert_locals "tag"
+    end
+  end
+
+  it "Rails tag helper with block and text" do
+    html = %(<%= tag.div do %>Content<% end %>)
+
+    expected = <<~PHLEX.strip
+      tag.div { text "Content" }
+    PHLEX
+
+    assert_phlex_template expected, html do
+      assert_locals "tag"
+    end
+  end
+
+  it "Rails tag helper with block and ERB output" do
+    html = %(<%= tag.div do %><%= content %><% end %>)
+
+    expected = <<~PHLEX.strip
+      tag.div { text content }
+    PHLEX
+
+    assert_phlex_template expected, html do
+      assert_locals "tag", "content"
+    end
+  end
+end

--- a/gem/test/phlexing/converter/rails_helpers_test.rb
+++ b/gem/test/phlexing/converter/rails_helpers_test.rb
@@ -1,0 +1,233 @@
+# frozen_string_literal: true
+
+require_relative "../../test_helper"
+
+class Phlexing::Converter::RailsHelpersTest < Minitest::Spec
+  it "Rails tag helper with block and text" do
+    html = %(<%= tag.div do %>Content<% end %>)
+
+    expected = <<~PHLEX.strip
+      tag.div { text "Content" }
+    PHLEX
+
+    assert_phlex_template expected, html do
+      assert_locals "tag"
+    end
+  end
+
+  it "Rails tag helper with block and ERB output" do
+    html = %(<%= tag.div do %><%= content %><% end %>)
+
+    expected = <<~PHLEX.strip
+      tag.div { text content }
+    PHLEX
+
+    assert_phlex_template expected, html do
+      assert_locals "tag", "content"
+    end
+  end
+
+  it "Rails content_tag helper with block and text" do
+    html = %(<%= content_tag :div do %>Content<% end %>)
+
+    expected = <<~PHLEX.strip
+      content_tag :div do
+        text "Content"
+      end
+    PHLEX
+
+    assert_phlex_template expected, html
+  end
+
+  it "Rails content_tag helper with block and attributes" do
+    html = %(<%= content_tag :div, class: "container", data: { controller: "content" } do %>Content<% end %>)
+
+    expected = <<~PHLEX.strip
+      content_tag :div, class: "container", data: { controller: "content" } do
+        text "Content"
+      end
+    PHLEX
+
+    assert_phlex_template expected, html
+  end
+
+  it "Rails content_tag helper with block and ERB output" do
+    html = %(<%= content_tag :div do %><%= content %><% end %>)
+
+    expected = <<~PHLEX.strip
+      content_tag :div do
+        text content
+      end
+    PHLEX
+
+    assert_phlex_template expected, html do
+      assert_locals "content"
+    end
+  end
+
+  it "Rails content_tag helper with block and ERB output" do
+    html = %(<%= content_tag :div do %><%= content %><% end %>)
+
+    expected = <<~PHLEX.strip
+      content_tag :div do
+        text content
+      end
+    PHLEX
+
+    assert_phlex_template expected, html do
+      assert_locals "content"
+    end
+  end
+
+  it "Rails form_for helper with block and ERB output" do
+    html = %(<%= form_for :article, @article do |f| %><%= f.blah %><% end %>)
+
+    expected = <<~PHLEX.strip
+      form_for :article, @article do |f|
+        text f.blah
+      end
+    PHLEX
+
+    assert_phlex_template expected, html do
+      assert_ivars "article"
+    end
+  end
+
+  it "Rails form_with helper with block and ERB output" do
+    html = %(<%= form_with :article, @article do |f| %><%= f.blah %><% end %>)
+
+    expected = <<~PHLEX.strip
+      form_with :article, @article do |f|
+        text f.blah
+      end
+    PHLEX
+
+    assert_phlex_template expected, html do
+      assert_ivars "article"
+    end
+  end
+
+  it "Rails image_tag helper" do
+    html = %(<%= image_tag image_path("/asset") %>Text)
+
+    expected = <<~PHLEX.strip
+      image_tag image_path("/asset")
+
+      text "Text"
+    PHLEX
+
+    assert_phlex_template expected, html
+  end
+
+  it "Rails check_box_tag helper" do
+    html = %(<%= check_box_tag(:pet_dog) %>Text)
+
+    expected = <<~PHLEX.strip
+      check_box_tag(:pet_dog)
+
+      text "Text"
+    PHLEX
+
+    assert_phlex_template expected, html
+  end
+
+  it "Rails text_field helper" do
+    html = %(<%= text_field(:person, :name) %>Text)
+
+    expected = <<~PHLEX.strip
+      text_field(:person, :name)
+
+      text "Text"
+    PHLEX
+
+    assert_phlex_template expected, html
+  end
+
+  it "Rails options_for_select helper" do
+    html = %(<%= options_for_select([['Lisbon', 1], ['Madrid', 2]]) %>Text)
+
+    expected = <<~PHLEX.strip
+      options_for_select([["Lisbon", 1], ["Madrid", 2]])
+
+      text "Text"
+    PHLEX
+
+    assert_phlex_template expected, html
+  end
+
+  it "Rails collection_select helper" do
+    html = %(<%= collection_select([]) %>Text)
+
+    expected = <<~PHLEX.strip
+      collection_select([])
+
+      text "Text"
+    PHLEX
+
+    assert_phlex_template expected, html
+  end
+
+  it "Rails options_from_collection_for_select helper" do
+    html = %(<%= options_from_collection_for_select([]) %>Text)
+
+    expected = <<~PHLEX.strip
+      options_from_collection_for_select([])
+
+      text "Text"
+    PHLEX
+
+    assert_phlex_template expected, html
+  end
+
+  it "Rails select_date helper" do
+    html = %(<%= select_date Date.today, prefix: :start_date %>Text)
+
+    expected = <<~PHLEX.strip
+      select_date Date.today, prefix: :start_date
+
+      text "Text"
+    PHLEX
+
+    assert_phlex_template expected, html
+  end
+
+  it "Rails select_year helper" do
+    html = %(<%= select_year(2009) %>Text)
+
+    expected = <<~PHLEX.strip
+      select_year(2009)
+
+      text "Text"
+    PHLEX
+
+    assert_phlex_template expected, html
+  end
+
+  it "Rails link_to helper" do
+    html = %(<%= link_to "Abc", user_path %>Text)
+
+    expected = <<~PHLEX.strip
+      link_to "Abc", user_path
+
+      text "Text"
+    PHLEX
+
+    assert_phlex_template expected, html do
+      assert_locals "user_path"
+    end
+  end
+
+  it "Rails url_for helper" do
+    html = %(<%= url_for post %>Text)
+
+    expected = <<~PHLEX.strip
+      url_for post
+
+      text "Text"
+    PHLEX
+
+    assert_phlex_template expected, html do
+      assert_locals "post"
+    end
+  end
+end

--- a/gem/test/phlexing/converter/rails_helpers_test.rb
+++ b/gem/test/phlexing/converter/rails_helpers_test.rb
@@ -230,4 +230,38 @@ class Phlexing::Converter::RailsHelpersTest < Minitest::Spec
       assert_locals "post"
     end
   end
+
+  it "Rails content_for helper" do
+    html = <<~ERB.strip
+      <ul><%= content_for :navigation %></ul>
+      Text
+    ERB
+
+    expected = <<~PHLEX.strip
+      ul { content_for :navigation }
+
+      text "Text"
+    PHLEX
+
+    assert_phlex_template expected, html
+  end
+
+  it "Rails content_for helper with block" do
+    html = <<~ERB.strip
+      <% content_for :navigation do %>
+        <li><%= link_to 'Home', action: 'index' %></li>
+      <% end %>
+      Text
+    ERB
+
+    expected = <<~PHLEX.strip
+      content_for :navigation do
+        li { link_to "Home", action: "index" }
+      end
+
+      text "Text"
+    PHLEX
+
+    assert_phlex_template expected, html
+  end
 end


### PR DESCRIPTION
This pull request adds primitive detection for Rails helpers.

Previously most of the Rails helpers were prefixed with a `text (...)` even though it wasn't necessary.

This potentially fixes #49 and fixes #50