### PR TITLE
Support standalone `<head>` tags

### DIFF
--- a/gem/lib/phlexing/erb_transformer.rb
+++ b/gem/lib/phlexing/erb_transformer.rb
@@ -25,7 +25,7 @@ module Phlexing
     end
 
     def self.transform_erb_tags(source)
-      Deface::Parser.convert(source).to_html
+      Deface::Parser.erb_markup!(source)
     end
 
     def self.transform_whitespace(source)

--- a/gem/lib/phlexing/parser.rb
+++ b/gem/lib/phlexing/parser.rb
@@ -5,7 +5,6 @@ require "nokogiri"
 module Phlexing
   class Parser
     def self.parse(source)
-      initial = source
       source = ErbTransformer.transform(source.to_s)
       source = Minifier.minify(source)
 
@@ -19,9 +18,9 @@ module Phlexing
 
       if source =~ html_tag
         Nokogiri::HTML::Document.parse(source)
-      elsif initial =~ head_tag && source =~ body_tag
+      elsif source =~ head_tag && source =~ body_tag
         Nokogiri::HTML::Document.parse(source).css("html").first
-      elsif initial =~ head_tag
+      elsif source =~ head_tag
         Nokogiri::HTML::Document.parse(source).css("head").first
       elsif source =~ body_tag
         Nokogiri::HTML::Document.parse(source).css("body").first

--- a/gem/test/phlexing/converter/tags_test.rb
+++ b/gem/test/phlexing/converter/tags_test.rb
@@ -121,4 +121,62 @@ class Phlexing::Converter::CustomElementsTest < Minitest::Spec
 
     assert_phlex_template expected, html
   end
+
+  it "basic html document" do
+    html = <<~HTML.strip
+      <head></head>
+      <body></body>
+    HTML
+
+    expected = <<~PHLEX.strip
+      html do
+        head
+
+        body
+      end
+    PHLEX
+
+    assert_phlex_template expected, html
+  end
+
+  it "standlone head and body tag" do
+    html = <<~HTML.strip
+      <head></head>
+      <body></body>
+    HTML
+
+    expected = <<~PHLEX.strip
+      html do
+        head
+
+        body
+      end
+    PHLEX
+
+    assert_phlex_template expected, html
+  end
+
+  it "standlone head tag" do
+    html = <<~HTML.strip
+      <head></head>
+    HTML
+
+    expected = <<~PHLEX.strip
+      head
+    PHLEX
+
+    assert_phlex_template expected, html
+  end
+
+  it "standlone body tag" do
+    html = <<~HTML.strip
+      <body></body>
+    HTML
+
+    expected = <<~PHLEX.strip
+      body
+    PHLEX
+
+    assert_phlex_template expected, html
+  end
 end

--- a/gem/test/phlexing/erb_transformer_test.rb
+++ b/gem/test/phlexing/erb_transformer_test.rb
@@ -25,14 +25,14 @@ module Phlexing
 
     it "should transform erb" do
       input = %(<div><% "The Next line has text on it" %> More Text</div>  )
-      expected = %(<div><erb silent> "The Next line has text on it" </erb> More Text</div>)
+      expected = %(<div><erb silent> &quot;The Next line has text on it&quot; </erb> More Text</div>)
 
       assert_equal expected, ErbTransformer.transform(input)
     end
 
     it "should transform erb output" do
       input = %(<div><%= "The Next line has text on it" %> More Text</div>  )
-      expected = %(<div><erb loud> "The Next line has text on it" </erb> More Text</div>)
+      expected = %(<div><erb loud> &quot;The Next line has text on it&quot; </erb> More Text</div>)
 
       assert_equal expected, ErbTransformer.transform(input)
     end

--- a/gem/test/phlexing/parser_test.rb
+++ b/gem/test/phlexing/parser_test.rb
@@ -29,6 +29,7 @@ module Phlexing
 
       assert_equal "#document-fragment", extract_children(parser).join(",")
       assert_dom_equal "", parser.to_xml
+      assert_equal "#document-fragment", parser.name
       assert_equal Nokogiri::HTML4::DocumentFragment, parser.class
     end
 
@@ -37,6 +38,7 @@ module Phlexing
 
       assert_equal "#document-fragment", extract_children(parser).join(",")
       assert_dom_equal "", parser.to_xml
+      assert_equal "#document-fragment", parser.name
       assert_equal Nokogiri::HTML4::DocumentFragment, parser.class
     end
 
@@ -45,6 +47,7 @@ module Phlexing
 
       assert_equal "#document-fragment,div", extract_children(parser).join(",")
       assert_dom_equal %(<div></div>), parser.to_html
+      assert_equal "#document-fragment", parser.name
       assert_equal Nokogiri::HTML4::DocumentFragment, parser.class
     end
 
@@ -53,22 +56,34 @@ module Phlexing
 
       assert_equal "#document-fragment,div,erb,text", extract_children(parser).join(",")
       assert_dom_equal %(<div> <erb loud=""> some_method </erb> </div>), parser.to_xml
+      assert_equal "#document-fragment", parser.name
       assert_equal Nokogiri::HTML4::DocumentFragment, parser.class
+    end
+
+    it "should handle html" do
+      parser = Parser.parse("<html></html>")
+
+      assert_equal "document,html,html", extract_children(parser).join(",")
+      assert_dom_equal %(<html></html>), parser.to_xml
+      assert_equal "document", parser.name
+      assert_equal Nokogiri::HTML4::Document, parser.class
     end
 
     it "should handle html, head and body" do
       parser = Parser.parse("<html><head><title>Title</title></head><body><h1>Hello</h1></body></html>")
 
-      assert_equal "document,html,html,head,meta,title,text,body,h1,text", extract_children(parser).join(",")
+      assert_equal "document,html,html,head,title,text,body,h1,text", extract_children(parser).join(",")
       assert_dom_equal %(<html> <head> <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"> <title>Title</title> </head> <body><h1>Hello</h1></body> </html>), parser.to_xml
+      assert_equal "document", parser.name
       assert_equal Nokogiri::HTML4::Document, parser.class
     end
 
     it "should handle html and head" do
       parser = Parser.parse("<html><head><title>Title</title></head></html>")
 
-      assert_equal "document,html,html,head,meta,title,text", extract_children(parser).join(",")
+      assert_equal "document,html,html,head,title,text", extract_children(parser).join(",")
       assert_dom_equal %(<html><head> <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"> <title>Title</title> </head></html>), parser.to_xml
+      assert_equal "document", parser.name
       assert_equal Nokogiri::HTML4::Document, parser.class
     end
 
@@ -77,30 +92,52 @@ module Phlexing
 
       assert_equal "document,html,html,body,h1,text", extract_children(parser).join(",")
       assert_dom_equal %(<html><body><h1>Hello</h1></body></html>), parser.to_xml
+      assert_equal "document", parser.name
       assert_equal Nokogiri::HTML4::Document, parser.class
     end
 
-    xit "should handle head and body" do
+    it "should handle head and body" do
       parser = Parser.parse("<head><title>Title</title></head><body><h1>Hello</h1></body>")
 
-      assert_equal "head,meta,title,text,body,h1,text", extract_children(parser).join(",")
-      assert_dom_equal %(<head> <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"> <title>Title</title> </head> <body> <h1>Hello</h1> </body>), parser.to_xml
-      assert_equal Nokogiri::HTML4::Document, parser.class
+      assert_equal "html,head,title,text,body,h1,text", extract_children(parser).join(",")
+      assert_dom_equal %(<html> <head> <title>Title</title> </head> <body> <h1>Hello</h1> </body> </html>), parser.to_xml
+      assert_equal "html", parser.name
+      assert_equal Nokogiri::XML::Element, parser.class
     end
 
-    it "should handle head" do
+    it "should handle head with title" do
       parser = Parser.parse("<head><title>Title</title></head>")
 
       assert_equal "head,title,text", extract_children(parser).join(",")
       assert_dom_equal %(<head> <title>Title</title> </head>), parser.to_xml
+      assert_equal "head", parser.name
       assert_equal Nokogiri::XML::Element, parser.class
     end
 
-    it "should handle body" do
+    it "should handle head" do
+      parser = Parser.parse("<head></head>")
+
+      assert_equal "head", extract_children(parser).join(",")
+      assert_dom_equal %(<head><meta http-equiv="Content-Type" content="text/html; charset=UTF-8"></head>), parser.to_html
+      assert_equal "head", parser.name
+      assert_equal Nokogiri::XML::Element, parser.class
+    end
+
+    it "should handle body with h1" do
       parser = Parser.parse("<body><h1>Hello</h1></body>")
 
       assert_equal "body,h1,text", extract_children(parser).join(",")
       assert_dom_equal %(<body> <h1>Hello</h1> </body>), parser.to_xml
+      assert_equal "body", parser.name
+      assert_equal Nokogiri::XML::Element, parser.class
+    end
+
+    it "should handle body" do
+      parser = Parser.parse("<body></body>")
+
+      assert_equal "body", extract_children(parser).join(",")
+      assert_dom_equal %(<body></body>), parser.to_html
+      assert_equal "body", parser.name
       assert_equal Nokogiri::XML::Element, parser.class
     end
   end


### PR DESCRIPTION
### Case 1
**ERB Input:**
```erb
<head></head>
```

**Output:**
```ruby
head
```
### Case 2

**ERB Input:**
```erb
<head></head>
<body></body>
```

**Output:**
```ruby
html do
  head
  body 
end
```

### Case 3

**ERB Input:**
```erb
<html>
  <head></head>
  <body></body>
</html>
```

**Output:**
```ruby
html do
  head
  body
end
```



Fixes #61 
Fixes #62
Fixes #63