### PR TITLE
Support uppercase tag names

### DIFF
--- a/gem/lib/phlexing/erb_transformer.rb
+++ b/gem/lib/phlexing/erb_transformer.rb
@@ -21,7 +21,7 @@ module Phlexing
     end
 
     def self.transform_template_tags(source)
-      source.gsub("<template", "<template-tag").gsub("</template", "</template-tag")
+      source.gsub(/<template/i, "<template-tag").gsub(/<\/template/i, "</template-tag")
     end
 
     def self.transform_erb_tags(source)

--- a/gem/lib/phlexing/erb_transformer.rb
+++ b/gem/lib/phlexing/erb_transformer.rb
@@ -21,7 +21,7 @@ module Phlexing
     end
 
     def self.transform_template_tags(source)
-      source.gsub(/<template/i, "<template-tag").gsub(/<\/template/i, "</template-tag")
+      source.gsub(/<template/i, "<template-tag").gsub(%r{</template}i, "</template-tag")
     end
 
     def self.transform_erb_tags(source)

--- a/gem/lib/phlexing/parser.rb
+++ b/gem/lib/phlexing/parser.rb
@@ -12,9 +12,9 @@ module Phlexing
       # https://github.com/spree/deface/blob/6bf18df76715ee3eb3d0cd1b6eda822817ace91c/lib/deface/parser.rb#L105-L111
       #
 
-      html_tag = /<html.*?(?:(?!>)[\s\S])*>/
-      head_tag = /<head.*?(?:(?!>)[\s\S])*>/
-      body_tag = /<body.*?(?:(?!>)[\s\S])*>/
+      html_tag = /<html.*?(?:(?!>)[\s\S])*>/i
+      head_tag = /<head.*?(?:(?!>)[\s\S])*>/i
+      body_tag = /<body.*?(?:(?!>)[\s\S])*>/i
 
       if source =~ html_tag
         Nokogiri::HTML::Document.parse(source)

--- a/gem/test/phlexing/converter/tags_test.rb
+++ b/gem/test/phlexing/converter/tags_test.rb
@@ -2,12 +2,15 @@
 
 require_relative "../../test_helper"
 
-class Phlexing::Converter::CustomElementsTest < Minitest::Spec
+class Phlexing::Converter::TagsTest < Minitest::Spec
   it "basic tags" do
     assert_phlex_template "div", %(<div></div>)
     assert_phlex_template "span", %(<span></span>)
     assert_phlex_template "p", %(<p></p>)
     assert_phlex_template "template_tag", %(<template></template>)
+    assert_phlex_template "html", %(<html></html>)
+    assert_phlex_template "head", %(<head></head>)
+    assert_phlex_template "body", %(<body></body>)
   end
 
   it "basic self closing tag" do

--- a/gem/test/phlexing/converter/uppercase_tags_test.rb
+++ b/gem/test/phlexing/converter/uppercase_tags_test.rb
@@ -1,0 +1,88 @@
+# frozen_string_literal: true
+
+require_relative "../../test_helper"
+
+class Phlexing::Converter::UppercaseTagsTest < Minitest::Spec
+  it "basic uppercase tags" do
+    assert_phlex_template "div", %(<DIV></DIV>)
+    assert_phlex_template "span", %(<SPAN></SPAN>)
+    assert_phlex_template "p", %(<P></P>)
+    assert_phlex_template "template_tag", %(<TEMPLATE></TEMPLATE>)
+    assert_phlex_template "html", %(<HTML></HTML>)
+    assert_phlex_template "head", %(<HEAD></HEAD>)
+    assert_phlex_template "body", %(<BODY></BODY>)
+  end
+
+  it "standlone uppercase body tag" do
+    html = <<~HTML.strip
+      <BODY></BODY>
+    HTML
+
+    expected = <<~PHLEX.strip
+      body
+    PHLEX
+
+    assert_phlex_template expected, html
+  end
+
+  it "standlone uppercase head tag" do
+    html = <<~HTML.strip
+      <HEAD></HEAD>
+    HTML
+
+    expected = <<~PHLEX.strip
+      head
+    PHLEX
+
+    assert_phlex_template expected, html
+  end
+
+  it "standlone uppercase html tag" do
+    html = <<~HTML.strip
+      <HTML></HTML>
+    HTML
+
+    expected = <<~PHLEX.strip
+      html
+    PHLEX
+
+    assert_phlex_template expected, html
+  end
+
+  it "standlone uppercase head and body tag" do
+    html = <<~HTML.strip
+      <HEAD></HEAD>
+      <BODY></BODY>
+    HTML
+
+    expected = <<~PHLEX.strip
+      html do
+        head
+
+        body
+      end
+    PHLEX
+
+    assert_phlex_template expected, html
+  end
+
+  it "basic uppercase document" do
+    html = <<~HTML.strip
+      <HTML>
+        <HEAD></HEAD>
+        <BODY></BODY>
+      </HTML>
+    HTML
+
+    expected = <<~PHLEX.strip
+      html do
+        whitespace
+        head
+        whitespace
+        body
+      end
+    PHLEX
+
+    assert_phlex_template expected, html
+  end
+end


### PR DESCRIPTION
**ERB Input:**
```erb
<HTML>
  <HEAD></HEAD>
  <BODY></BODY>
</HTML>
```

**Output:**
```ruby
html do
  head
  body
end
```


Fixes #64 