### PR TITLE
Support ERB interpolation in HTML attributes

### DIFF
--- a/gem/lib/phlexing/helpers.rb
+++ b/gem/lib/phlexing/helpers.rb
@@ -34,6 +34,19 @@ module Phlexing
       CGI.unescapeHTML(source)
     end
 
+    def unwrap_erb(source)
+      source
+        .delete_prefix("<%==")
+        .delete_prefix("<%=")
+        .delete_prefix("<%-")
+        .delete_prefix("<%#")
+        .delete_prefix("<% #")
+        .delete_prefix("<%")
+        .delete_suffix("-%>")
+        .delete_suffix("%>")
+        .strip
+    end
+
     def tag_name(node)
       return "template_tag" if node.name == "template-tag"
 
@@ -85,6 +98,10 @@ module Phlexing
       filter_matched = regex_filter.map { |regex| word.scan(regex).any? }.reduce(:|)
 
       !(blocklist_matched || filter_matched)
+    end
+
+    def children?(node)
+      node.children.length >= 1
     end
 
     def multiple_children?(node)

--- a/gem/lib/phlexing/minifier.rb
+++ b/gem/lib/phlexing/minifier.rb
@@ -5,9 +5,23 @@ require "html_press"
 module Phlexing
   class Minifier
     def self.minify(source)
-      HtmlPress.press(source.to_s)
+      minified = HtmlPress.press(source.to_s)
+      minified = minify_html_entities(minified)
+
+      minified
     rescue StandardError
       source
+    end
+
+    def self.minify_html_entities(source)
+      source
+        .gsub("& lt;", "&lt;")
+        .gsub("& quot;", "&quot;")
+        .gsub("& gt;", "&gt;")
+        .gsub("& #amp;", "&#amp;")
+        .gsub("& #38;", "&#38;")
+        .gsub("& #60;", "&#60;")
+        .gsub("& #62;", "&#62;")
     end
   end
 end

--- a/gem/lib/phlexing/patches/html_press.rb
+++ b/gem/lib/phlexing/patches/html_press.rb
@@ -4,7 +4,24 @@ require "html_press"
 
 module HtmlPress
   class Html
+    # We want to preserve HTML comments in the minification step
+    # so we can output them again in the phlex template
     def process_html_comments(out)
+      out
+    end
+  end
+
+  class Entities
+    # The minification step turned this input
+    # <div data-erb-class="&lt;%= something? ? &quot;class-1&quot; : &quot;class-2&quot; %&gt;">Text</div>
+    #
+    # into this output:
+    # <div data-erb-class="&lt;%= something? ? " class-1"  :" class-2" %& gt;">Text</div>
+    #
+    # which in our wasn't ideal, because nokogiri parsed it as:
+    # <div data-erb-class="<%= something? ? " class-1="  :" class-2="%>">Text</div>
+    #
+    def minify(out)
       out
     end
   end

--- a/gem/test/phlexing/converter/attributes_test.rb
+++ b/gem/test/phlexing/converter/attributes_test.rb
@@ -1,0 +1,96 @@
+# frozen_string_literal: true
+
+require_relative "../../test_helper"
+
+class Phlexing::Converter::AttributesTest < Minitest::Spec
+  it "should interpolate ERB in attributes using <%=" do
+    html = <<~HTML.strip
+      <div class="<%= classes_helper %>">Text</div>
+    HTML
+
+    expected = <<~PHLEX.strip
+      div(class: (classes_helper)) { "Text" }
+    PHLEX
+
+    assert_phlex_template expected, html
+  end
+
+  it "should interpolate ERB in multiple attributes using <%=" do
+    html = <<~HTML.strip
+      <div class="<%= classes_helper %>" style="<%= true? ? "background: red" : "background: blue" %>">Text</div>
+    HTML
+
+    expected = <<~PHLEX.strip
+      div(
+        class: (classes_helper),
+        style: (true? ? "background: red" : "background: blue")
+      ) { "Text" }
+    PHLEX
+
+    assert_phlex_template expected, html
+  end
+
+  it "should not interpolate ERB in attributes using <%" do
+    html = <<~HTML.strip
+      <div class="<% classes_helper %>">Text</div>
+    HTML
+
+    expected = <<~PHLEX.strip
+      div(class: "FIXME: classes_helper") { "Text" }
+    PHLEX
+
+    assert_phlex_template expected, html
+  end
+
+  it "should interpolate ERB in attributes using <%= and if" do
+    html = <<~HTML.strip
+      <div class="<%= classes_helper if true %>">Text</div>
+    HTML
+
+    expected = <<~PHLEX.strip
+      div(class: (classes_helper if true)) { "Text" }
+    PHLEX
+
+    assert_phlex_template expected, html
+  end
+
+  it "should interpolate ERB conditional in attribute" do
+    html = <<~HTML.strip
+      <div class="<%= something? ? "class-1" : "class-2" %>">Text</div>
+    HTML
+
+    expected = <<~PHLEX.strip
+      div(class: (something? ? "class-1" : "class-2")) { "Text" }
+    PHLEX
+
+    assert_phlex_template expected, html
+  end
+
+  it "should interpolate ERB in tag" do
+    html = <<~HTML.strip
+      <input type="checkbox" <%= "selected" %> />
+    HTML
+
+    expected = <<~PHLEX.strip
+      input(type: %(checkbox), **(" selected": true))
+    PHLEX
+
+    assert_phlex_template expected, html
+  end
+
+  xit "should interpolate ERB in tag with interpoltion" do
+    # rubocop:disable Lint/InterpolationCheck
+    html = '<input type="checkbox" <%= "data-#{Time.now.to_i}"%> />'
+    expected = 'input(type: %(checkbox), **(" data-#{Time.now.to_i}": true))'
+    # rubocop:enable Lint/InterpolationCheck
+
+    assert_phlex_template expected, html
+  end
+
+  xit "should interpolate ERB in tag with conditional" do
+    html = %(<input type="checkbox" <%= "selected" if true %> />)
+    expected = %(input(type: %(checkbox), **(" selected": true)))
+
+    assert_phlex_template expected, html
+  end
+end


### PR DESCRIPTION
This pull request adds support for ERB interpolation in HTML attributes. This allows use-cases like:

**ERB Input:**
```erb
<div class="<%= classes_helper %>">Text</div>
```

**Output:**
```ruby
div(class: classes_helper) { "Text" }
```



Fixes https://github.com/marcoroth/phlexing/issues/48