### PR TITLE
Move `RubyAnalyzer.analyze` call to `ComponentGenerator`

### DIFF
--- a/gem/lib/phlexing/component_generator.rb
+++ b/gem/lib/phlexing/component_generator.rb
@@ -4,7 +4,7 @@ module Phlexing
   class ComponentGenerator
     include Helpers
 
-    attr_accessor :converter
+    attr_accessor :converter, :analyzer
 
     def self.generate(converter)
       new(converter).generate
@@ -12,6 +12,8 @@ module Phlexing
 
     def initialize(converter)
       @converter = converter
+      @analyzer = RubyAnalyzer.new
+      @analyzer.analyze(converter.source)
     end
 
     def generate
@@ -79,10 +81,6 @@ module Phlexing
 
     def build_accessors
       analyzer.locals.sort.map { |local| symbol(local) }.join(", ")
-    end
-
-    def analyzer
-      converter.analyzer
     end
 
     def options

--- a/gem/lib/phlexing/converter.rb
+++ b/gem/lib/phlexing/converter.rb
@@ -2,7 +2,7 @@
 
 module Phlexing
   class Converter
-    attr_accessor :source, :custom_elements, :options, :analyzer
+    attr_accessor :source, :custom_elements, :options
 
     def self.convert(source, **options)
       new(**options).convert(source)
@@ -10,14 +10,12 @@ module Phlexing
 
     def convert(source)
       @source = source
-      analyzer.analyze(source)
 
       code
     end
 
     def initialize(source = nil, **options)
       @custom_elements = Set.new
-      @analyzer = RubyAnalyzer.new
       @options = Options.new(**options)
 
       convert(source)

--- a/gem/lib/phlexing/ruby_analyzer.rb
+++ b/gem/lib/phlexing/ruby_analyzer.rb
@@ -18,9 +18,13 @@ module Phlexing
     end
 
     def analyze(source)
-      source = source.to_s
-      ruby = extract_ruby_from_erb(source)
-      program = SyntaxTree.parse(ruby)
+      code = extract_ruby_from_erb(source.to_s)
+
+      analyze_ruby(code)
+    end
+
+    def analyze_ruby(code)
+      program = SyntaxTree.parse(code)
       @visitor.visit(program)
 
       self

--- a/gem/test/test_helper.rb
+++ b/gem/test/test_helper.rb
@@ -25,61 +25,66 @@ end
 def assert_details(expected, source, generated_code, &block)
   assert_equal(expected, generated_code)
 
+  @analyzer = Phlexing::RubyAnalyzer.new
+  @analyzer.analyze(source)
+
   @assert_custom_elements_called = false
   @assert_ivars_called = false
   @assert_locals_called = false
+  @assert_idents_called = false
 
   block&.call(self)
 
   assert_custom_elements unless @assert_custom_elements_called
   assert_ivars unless @assert_ivars_called
   assert_locals unless @assert_locals_called
+  # assert_idents unless @assert_idents_called
 end
 
 def assert_custom_elements(*elements)
-  raise "Make sure assert_custom_elements is called within the block passed to assert_phlex" if @converter.nil?
+  raise "Make sure assert_custom_elements is called within the block passed to assert_phlex" if @analyzer.nil?
 
   @assert_custom_elements_called = true
 
   assert_equal(
     elements.sort,
     @converter.custom_elements.to_a.sort,
-    "Phlex::Converter.custom_elements"
+    "assert_custom_elements"
   )
 end
 
 def assert_ivars(*ivars)
-  raise "Make sure assert_ivars is called within the block passed to assert_phlex" if @converter.nil?
+  raise "Make sure assert_ivars is called within the block passed to assert_phlex" if @analyzer.nil?
 
   @assert_ivars_called = true
 
   assert_equal(
     ivars.sort,
-    @converter.analyzer.ivars.to_a.sort,
-    "Phlex::Converter.ivars"
+    @analyzer.ivars.to_a.sort,
+    "assert_ivars"
   )
 end
 
 def assert_locals(*locals)
-  raise "Make sure assert_locals is called within the block passed to assert_phlex" if @converter.nil?
+  raise "Make sure assert_locals is called within the block passed to assert_phlex" if @analyzer.nil?
 
   @assert_locals_called = true
 
   assert_equal(
     locals.sort,
-    @converter.analyzer.locals.to_a.sort,
-    "Phlex::Converter.locals"
+    @analyzer.locals.to_a.sort,
+    "assert_locals"
   )
 end
 
 def assert_idents(*idents)
-  raise "Make sure assert_idents is called within the block passed to assert_phlex" if @converter.nil?
+  raise "Make sure assert_idents is called within the block passed to assert_phlex" if @analyzer.nil?
 
   @assert_idents_called = true
 
   assert_equal(
     idents.sort,
-    @converter.analyzer.idents.to_a.sort,
-    "Phlex::Converter.idents"
+    @analyzer.idents.to_a.sort,
+    "assert_idents"
   )
 end


### PR DESCRIPTION
The `RubyAnalyzer.analyze` call is unnecessary in the `Converter` if we are only generating the code for the template method.

Since we are anyway only using the analyzer inside the `ComponentGenerator` it makes more sense to also store it in that class.