### PR TITLE
Enhance `RubyAnalyzer` to detect `instance_methods` and more

### DIFF
--- a/gem/lib/phlexing/ruby_analyzer.rb
+++ b/gem/lib/phlexing/ruby_analyzer.rb
@@ -4,7 +4,7 @@ require "syntax_tree"
 
 module Phlexing
   class RubyAnalyzer
-    attr_accessor :ivars, :locals, :idents
+    attr_accessor :ivars, :locals, :idents, :calls, :consts, :instance_methods
 
     def self.analyze(source)
       new.analyze(source)
@@ -14,6 +14,9 @@ module Phlexing
       @ivars = Set.new
       @locals = Set.new
       @idents = Set.new
+      @calls = Set.new
+      @consts = Set.new
+      @instance_methods = Set.new
       @visitor = Visitor.new(self)
     end
 

--- a/gem/lib/phlexing/visitor.rb
+++ b/gem/lib/phlexing/visitor.rb
@@ -14,6 +14,61 @@ module Phlexing
       @converter.ivars << node.value.from(1)
     end
 
+    def visit_const(node)
+      @converter.consts << node.value
+    end
+
+    def visit_command(node)
+      @converter.instance_methods << node.message.value
+      super
+    end
+
+    def visit_call(node)
+      if node.receiver
+        case node.receiver
+        when SyntaxTree::VarRef
+          value = node.receiver.value.value
+
+          case node.receiver.value
+          when SyntaxTree::IVar
+            @converter.ivars << value.from(1)
+          when SyntaxTree::Ident
+            @converter.idents << value
+          end
+
+          @converter.calls << value
+
+        when SyntaxTree::VCall
+          case node.receiver.value
+          when SyntaxTree::Ident
+            @converter.calls << node.receiver.value.value
+          end
+
+        when SyntaxTree::Ident
+          value = node.receiver.value.value.value
+
+          @converter.idents << value unless value.ends_with?("?")
+          @converter.calls << value
+
+        when SyntaxTree::Const
+          @converter.calls << node.receiver.value
+        end
+
+      elsif node.receiver.nil? && node.operator.nil?
+        case node.message
+        when SyntaxTree::Ident
+          if node.message.value.end_with?("?") || node.child_nodes[3].is_a?(SyntaxTree::ArgParen)
+            @converter.instance_methods << node.message.value
+            @converter.calls << node.message.value
+          else
+            @converter.idents << node.message.value
+          end
+        end
+      end
+
+      super
+    end
+
     def visit_vcall(node)
       @converter.locals << node.value.value
     end

--- a/gem/test/phlexing/converter/erb_test.rb
+++ b/gem/test/phlexing/converter/erb_test.rb
@@ -226,6 +226,7 @@ class Phlexing::Converter::ErbTest < Minitest::Spec
 
     assert_phlex_template expected, html do
       assert_ivars "greeting"
+      assert_consts "Time"
     end
   end
 

--- a/gem/test/phlexing/converter/rails_helpers_test.rb
+++ b/gem/test/phlexing/converter/rails_helpers_test.rb
@@ -36,7 +36,9 @@ class Phlexing::Converter::RailsHelpersTest < Minitest::Spec
       end
     PHLEX
 
-    assert_phlex_template expected, html
+    assert_phlex_template expected, html do
+      assert_instance_methods "content_tag"
+    end
   end
 
   it "Rails content_tag helper with block and attributes" do
@@ -48,20 +50,8 @@ class Phlexing::Converter::RailsHelpersTest < Minitest::Spec
       end
     PHLEX
 
-    assert_phlex_template expected, html
-  end
-
-  it "Rails content_tag helper with block and ERB output" do
-    html = %(<%= content_tag :div do %><%= content %><% end %>)
-
-    expected = <<~PHLEX.strip
-      content_tag :div do
-        text content
-      end
-    PHLEX
-
     assert_phlex_template expected, html do
-      assert_locals "content"
+      assert_instance_methods "content_tag"
     end
   end
 
@@ -76,6 +66,22 @@ class Phlexing::Converter::RailsHelpersTest < Minitest::Spec
 
     assert_phlex_template expected, html do
       assert_locals "content"
+      assert_instance_methods "content_tag"
+    end
+  end
+
+  it "Rails content_tag helper with block and ERB output" do
+    html = %(<%= content_tag :div do %><%= content %><% end %>)
+
+    expected = <<~PHLEX.strip
+      content_tag :div do
+        text content
+      end
+    PHLEX
+
+    assert_phlex_template expected, html do
+      assert_locals "content"
+      assert_instance_methods "content_tag"
     end
   end
 
@@ -90,6 +96,7 @@ class Phlexing::Converter::RailsHelpersTest < Minitest::Spec
 
     assert_phlex_template expected, html do
       assert_ivars "article"
+      assert_instance_methods "form_for"
     end
   end
 
@@ -104,6 +111,7 @@ class Phlexing::Converter::RailsHelpersTest < Minitest::Spec
 
     assert_phlex_template expected, html do
       assert_ivars "article"
+      assert_instance_methods "form_with"
     end
   end
 
@@ -116,7 +124,9 @@ class Phlexing::Converter::RailsHelpersTest < Minitest::Spec
       text "Text"
     PHLEX
 
-    assert_phlex_template expected, html
+    assert_phlex_template expected, html do
+      assert_instance_methods "image_tag", "image_path"
+    end
   end
 
   it "Rails check_box_tag helper" do
@@ -128,7 +138,9 @@ class Phlexing::Converter::RailsHelpersTest < Minitest::Spec
       text "Text"
     PHLEX
 
-    assert_phlex_template expected, html
+    assert_phlex_template expected, html do
+      assert_instance_methods "check_box_tag"
+    end
   end
 
   it "Rails text_field helper" do
@@ -140,7 +152,9 @@ class Phlexing::Converter::RailsHelpersTest < Minitest::Spec
       text "Text"
     PHLEX
 
-    assert_phlex_template expected, html
+    assert_phlex_template expected, html do
+      assert_instance_methods "text_field"
+    end
   end
 
   it "Rails options_for_select helper" do
@@ -152,7 +166,9 @@ class Phlexing::Converter::RailsHelpersTest < Minitest::Spec
       text "Text"
     PHLEX
 
-    assert_phlex_template expected, html
+    assert_phlex_template expected, html do
+      assert_instance_methods "options_for_select"
+    end
   end
 
   it "Rails collection_select helper" do
@@ -164,7 +180,9 @@ class Phlexing::Converter::RailsHelpersTest < Minitest::Spec
       text "Text"
     PHLEX
 
-    assert_phlex_template expected, html
+    assert_phlex_template expected, html do
+      assert_instance_methods "collection_select"
+    end
   end
 
   it "Rails options_from_collection_for_select helper" do
@@ -176,7 +194,9 @@ class Phlexing::Converter::RailsHelpersTest < Minitest::Spec
       text "Text"
     PHLEX
 
-    assert_phlex_template expected, html
+    assert_phlex_template expected, html do
+      assert_instance_methods "options_from_collection_for_select"
+    end
   end
 
   it "Rails select_date helper" do
@@ -188,7 +208,10 @@ class Phlexing::Converter::RailsHelpersTest < Minitest::Spec
       text "Text"
     PHLEX
 
-    assert_phlex_template expected, html
+    assert_phlex_template expected, html do
+      assert_instance_methods "select_date"
+      assert_consts "Date"
+    end
   end
 
   it "Rails select_year helper" do
@@ -200,7 +223,9 @@ class Phlexing::Converter::RailsHelpersTest < Minitest::Spec
       text "Text"
     PHLEX
 
-    assert_phlex_template expected, html
+    assert_phlex_template expected, html do
+      assert_instance_methods "select_year"
+    end
   end
 
   it "Rails link_to helper" do
@@ -214,6 +239,7 @@ class Phlexing::Converter::RailsHelpersTest < Minitest::Spec
 
     assert_phlex_template expected, html do
       assert_locals "user_path"
+      assert_instance_methods "link_to"
     end
   end
 
@@ -228,6 +254,7 @@ class Phlexing::Converter::RailsHelpersTest < Minitest::Spec
 
     assert_phlex_template expected, html do
       assert_locals "post"
+      assert_instance_methods "url_for"
     end
   end
 
@@ -243,7 +270,9 @@ class Phlexing::Converter::RailsHelpersTest < Minitest::Spec
       text "Text"
     PHLEX
 
-    assert_phlex_template expected, html
+    assert_phlex_template expected, html do
+      assert_instance_methods "content_for"
+    end
   end
 
   it "Rails content_for helper with block" do
@@ -262,6 +291,8 @@ class Phlexing::Converter::RailsHelpersTest < Minitest::Spec
       text "Text"
     PHLEX
 
-    assert_phlex_template expected, html
+    assert_phlex_template expected, html do
+      assert_instance_methods "content_for", "link_to"
+    end
   end
 end

--- a/gem/test/phlexing/converter_test.rb
+++ b/gem/test/phlexing/converter_test.rb
@@ -15,7 +15,10 @@ class Phlexing::ConverterTest < Minitest::Spec
       text "Hello"
     PHLEX
 
-    assert_phlex_template expected, html
+    assert_phlex_template expected, html do
+      assert_consts "SomeView"
+      assert_instance_methods "render"
+    end
   end
 
   it "should generate phlex class with component name" do

--- a/gem/test/phlexing/ruby_analyzer_test.rb
+++ b/gem/test/phlexing/ruby_analyzer_test.rb
@@ -5,181 +5,130 @@ require_relative "../test_helper"
 module Phlexing
   class RubyAnalyzerTest < Minitest::Spec
     it "should handle nil" do
-      @analyzer = RubyAnalyzer.analyze(nil)
-
-      assert_ivars
-      assert_locals
-      assert_idents
-      assert_calls
-      assert_consts
-      assert_instance_methods
+      assert_analyzed(nil)
     end
 
     it "should handle empty string" do
-      @analyzer = RubyAnalyzer.analyze("")
-
-      assert_ivars
-      assert_locals
-      assert_idents
-      assert_calls
-      assert_consts
-      assert_instance_methods
+      assert_analyzed("")
     end
 
     it "should handle local" do
       input = %(<% some %>)
 
-      @analyzer = RubyAnalyzer.analyze(input)
-
-      assert_ivars
-      assert_locals "some"
-      assert_idents
-      assert_calls
-      assert_consts
-      assert_instance_methods
+      assert_analyzed(input) do
+        assert_locals "some"
+      end
     end
 
     it "should handle method with parens" do
       input = %(<% some() %>)
 
-      @analyzer = RubyAnalyzer.analyze(input)
-
-      assert_ivars
-      assert_locals
-      assert_idents "some"
-      assert_calls "some"
-      assert_consts
-      assert_instance_methods "some"
+      assert_analyzed(input) do
+        assert_idents "some"
+        assert_calls "some"
+        assert_instance_methods "some"
+      end
     end
 
     it "should handle method with parens and args" do
       input = %(<% some(@thing) %>)
 
-      @analyzer = RubyAnalyzer.analyze(input)
-
-      assert_ivars "thing"
-      assert_locals
-      assert_idents "some"
-      assert_calls "some"
-      assert_consts
-      assert_instance_methods "some"
+      assert_analyzed(input) do
+        assert_ivars "thing"
+        assert_idents "some"
+        assert_calls "some"
+        assert_instance_methods "some"
+      end
     end
 
     it "should handle local with questionmark" do
       input = %(<% some? %>)
 
-      @analyzer = RubyAnalyzer.analyze(input)
-
-      assert_ivars
-      assert_locals
-      assert_idents "some?"
-      assert_calls "some?"
-      assert_consts
-      assert_instance_methods "some?"
+      assert_analyzed(input) do
+        assert_idents "some?"
+        assert_calls "some?"
+        assert_instance_methods "some?"
+      end
     end
 
     it "should handle local with questionmark and parens" do
       input = %(<% some?() %>)
 
-      @analyzer = RubyAnalyzer.analyze(input)
-
-      assert_ivars
-      assert_locals
-      assert_idents "some?"
-      assert_calls "some?"
-      assert_consts
-      assert_instance_methods "some?"
+      assert_analyzed(input) do
+        assert_idents "some?"
+        assert_calls "some?"
+        assert_instance_methods "some?"
+      end
     end
 
     it "should handle local with questionmark and parens and arguments" do
       input = %(<% some?(@thing) %>)
 
-      @analyzer = RubyAnalyzer.analyze(input)
-
-      assert_ivars "thing"
-      assert_locals
-      assert_idents "some?"
-      assert_calls "some?"
-      assert_consts
-      assert_instance_methods "some?"
+      assert_analyzed(input) do
+        assert_ivars "thing"
+        assert_idents "some?"
+        assert_calls "some?"
+        assert_instance_methods "some?"
+      end
     end
 
     it "should handle method call on local" do
       input = %(<% some.something %>)
 
-      @analyzer = RubyAnalyzer.analyze(input)
-
-      assert_ivars
-      assert_locals "some"
-      assert_idents "something"
-      assert_calls "some"
-      assert_consts
-      assert_instance_methods
+      assert_analyzed(input) do
+        assert_locals "some"
+        assert_idents "something"
+        assert_calls "some"
+      end
     end
 
     it "should handle method call with question mark on local" do
       input = %(<% some.something? %>)
 
-      @analyzer = RubyAnalyzer.analyze(input)
-
-      assert_ivars
-      assert_locals "some"
-      assert_idents "something?"
-      assert_calls "some"
-      assert_consts
-      assert_instance_methods
+      assert_analyzed(input) do
+        assert_locals "some"
+        assert_idents "something?"
+        assert_calls "some"
+      end
     end
 
     it "should handle method call with block on local" do
       input = %(<%= tag.div do %>Content<% end %>)
 
-      @analyzer = RubyAnalyzer.analyze(input)
-
-      assert_ivars
-      assert_locals "tag"
-      assert_idents "div"
-      assert_calls "tag"
-      assert_consts
-      assert_instance_methods
+      assert_analyzed(input) do
+        assert_locals "tag"
+        assert_idents "div"
+        assert_calls "tag"
+      end
     end
 
     it "should handle method call on ivar" do
       input = %(<% @some.something? %>)
 
-      @analyzer = RubyAnalyzer.analyze(input)
-
-      assert_ivars "some"
-      assert_locals
-      assert_idents "something?"
-      assert_calls "@some"
-      assert_consts
-      assert_instance_methods
+      assert_analyzed(input) do
+        assert_ivars "some"
+        assert_idents "something?"
+        assert_calls "@some"
+      end
     end
 
     it "should handle method call on Const" do
       input = %(<% Some.something? %>)
 
-      @analyzer = RubyAnalyzer.analyze(input)
-
-      assert_ivars
-      assert_locals
-      assert_idents "something?"
-      assert_calls "Some"
-      assert_consts "Some"
-      assert_instance_methods
+      assert_analyzed(input) do
+        assert_idents "something?"
+        assert_calls "Some"
+        assert_consts "Some"
+      end
     end
 
     it "should handle method call on Const" do
       input = %(<%= content_tag :div do %>content<% end %>)
 
-      @analyzer = RubyAnalyzer.analyze(input)
-
-      assert_ivars
-      assert_locals
-      assert_idents "content_tag", "div"
-      assert_calls
-      assert_consts
-      assert_instance_methods "content_tag"
+      assert_analyzed(input) do
+        assert_idents "content_tag", "div"
+        assert_instance_methods "content_tag"
+      end
     end
   end
 end

--- a/gem/test/phlexing/ruby_analyzer_test.rb
+++ b/gem/test/phlexing/ruby_analyzer_test.rb
@@ -5,19 +5,181 @@ require_relative "../test_helper"
 module Phlexing
   class RubyAnalyzerTest < Minitest::Spec
     it "should handle nil" do
-      analyzer = RubyAnalyzer.analyze(nil)
+      @analyzer = RubyAnalyzer.analyze(nil)
 
-      assert_equal [], analyzer.ivars.to_a
-      assert_equal [], analyzer.locals.to_a
-      assert_equal [], analyzer.idents.to_a
+      assert_ivars
+      assert_locals
+      assert_idents
+      assert_calls
+      assert_consts
+      assert_instance_methods
     end
 
     it "should handle empty string" do
-      analyzer = RubyAnalyzer.analyze("")
+      @analyzer = RubyAnalyzer.analyze("")
 
-      assert_equal [], analyzer.ivars.to_a
-      assert_equal [], analyzer.locals.to_a
-      assert_equal [], analyzer.idents.to_a
+      assert_ivars
+      assert_locals
+      assert_idents
+      assert_calls
+      assert_consts
+      assert_instance_methods
+    end
+
+    it "should handle local" do
+      input = %(<% some %>)
+
+      @analyzer = RubyAnalyzer.analyze(input)
+
+      assert_ivars
+      assert_locals "some"
+      assert_idents
+      assert_calls
+      assert_consts
+      assert_instance_methods
+    end
+
+    it "should handle method with parens" do
+      input = %(<% some() %>)
+
+      @analyzer = RubyAnalyzer.analyze(input)
+
+      assert_ivars
+      assert_locals
+      assert_idents "some"
+      assert_calls "some"
+      assert_consts
+      assert_instance_methods "some"
+    end
+
+    it "should handle method with parens and args" do
+      input = %(<% some(@thing) %>)
+
+      @analyzer = RubyAnalyzer.analyze(input)
+
+      assert_ivars "thing"
+      assert_locals
+      assert_idents "some"
+      assert_calls "some"
+      assert_consts
+      assert_instance_methods "some"
+    end
+
+    it "should handle local with questionmark" do
+      input = %(<% some? %>)
+
+      @analyzer = RubyAnalyzer.analyze(input)
+
+      assert_ivars
+      assert_locals
+      assert_idents "some?"
+      assert_calls "some?"
+      assert_consts
+      assert_instance_methods "some?"
+    end
+
+    it "should handle local with questionmark and parens" do
+      input = %(<% some?() %>)
+
+      @analyzer = RubyAnalyzer.analyze(input)
+
+      assert_ivars
+      assert_locals
+      assert_idents "some?"
+      assert_calls "some?"
+      assert_consts
+      assert_instance_methods "some?"
+    end
+
+    it "should handle local with questionmark and parens and arguments" do
+      input = %(<% some?(@thing) %>)
+
+      @analyzer = RubyAnalyzer.analyze(input)
+
+      assert_ivars "thing"
+      assert_locals
+      assert_idents "some?"
+      assert_calls "some?"
+      assert_consts
+      assert_instance_methods "some?"
+    end
+
+    it "should handle method call on local" do
+      input = %(<% some.something %>)
+
+      @analyzer = RubyAnalyzer.analyze(input)
+
+      assert_ivars
+      assert_locals "some"
+      assert_idents "something"
+      assert_calls "some"
+      assert_consts
+      assert_instance_methods
+    end
+
+    it "should handle method call with question mark on local" do
+      input = %(<% some.something? %>)
+
+      @analyzer = RubyAnalyzer.analyze(input)
+
+      assert_ivars
+      assert_locals "some"
+      assert_idents "something?"
+      assert_calls "some"
+      assert_consts
+      assert_instance_methods
+    end
+
+    it "should handle method call with block on local" do
+      input = %(<%= tag.div do %>Content<% end %>)
+
+      @analyzer = RubyAnalyzer.analyze(input)
+
+      assert_ivars
+      assert_locals "tag"
+      assert_idents "div"
+      assert_calls "tag"
+      assert_consts
+      assert_instance_methods
+    end
+
+    it "should handle method call on ivar" do
+      input = %(<% @some.something? %>)
+
+      @analyzer = RubyAnalyzer.analyze(input)
+
+      assert_ivars "some"
+      assert_locals
+      assert_idents "something?"
+      assert_calls "@some"
+      assert_consts
+      assert_instance_methods
+    end
+
+    it "should handle method call on Const" do
+      input = %(<% Some.something? %>)
+
+      @analyzer = RubyAnalyzer.analyze(input)
+
+      assert_ivars
+      assert_locals
+      assert_idents "something?"
+      assert_calls "Some"
+      assert_consts "Some"
+      assert_instance_methods
+    end
+
+    it "should handle method call on Const" do
+      input = %(<%= content_tag :div do %>content<% end %>)
+
+      @analyzer = RubyAnalyzer.analyze(input)
+
+      assert_ivars
+      assert_locals
+      assert_idents "content_tag", "div"
+      assert_calls
+      assert_consts
+      assert_instance_methods "content_tag"
     end
   end
 end

--- a/gem/test/test_helper.rb
+++ b/gem/test/test_helper.rb
@@ -25,10 +25,17 @@ end
 def assert_details(expected, source, generated_code, &block)
   assert_equal(expected, generated_code)
 
+  @assert_custom_elements_called = false
+
+  assert_analyzed(source, all: false, &block)
+
+  assert_custom_elements unless @assert_custom_elements_called
+end
+
+def assert_analyzed(source, all: true, &block)
   @analyzer = Phlexing::RubyAnalyzer.new
   @analyzer.analyze(source)
 
-  @assert_custom_elements_called = false
   @assert_ivars_called = false
   @assert_locals_called = false
   @assert_idents_called = false
@@ -38,13 +45,15 @@ def assert_details(expected, source, generated_code, &block)
 
   block&.call(self)
 
-  assert_custom_elements unless @assert_custom_elements_called
   assert_ivars unless @assert_ivars_called
   assert_locals unless @assert_locals_called
-  # assert_idents unless @assert_idents_called
   assert_consts unless @assert_consts_called
-  # assert_calls unless @assert_calls_called
   assert_instance_methods unless @assert_instance_methods_called
+
+  if all
+    assert_idents unless @assert_idents_called
+    assert_calls unless @assert_calls_called
+  end
 end
 
 def assert_custom_elements(*elements)

--- a/gem/test/test_helper.rb
+++ b/gem/test/test_helper.rb
@@ -32,6 +32,9 @@ def assert_details(expected, source, generated_code, &block)
   @assert_ivars_called = false
   @assert_locals_called = false
   @assert_idents_called = false
+  @assert_calls_called = false
+  @assert_consts_called = false
+  @assert_instance_methods_called = false
 
   block&.call(self)
 
@@ -39,6 +42,9 @@ def assert_details(expected, source, generated_code, &block)
   assert_ivars unless @assert_ivars_called
   assert_locals unless @assert_locals_called
   # assert_idents unless @assert_idents_called
+  assert_consts unless @assert_consts_called
+  # assert_calls unless @assert_calls_called
+  assert_instance_methods unless @assert_instance_methods_called
 end
 
 def assert_custom_elements(*elements)
@@ -86,5 +92,41 @@ def assert_idents(*idents)
     idents.sort,
     @analyzer.idents.to_a.sort,
     "assert_idents"
+  )
+end
+
+def assert_calls(*calls)
+  raise "Make sure assert_calls is called within the block passed to assert_phlex" if @analyzer.nil?
+
+  @assert_calls_called = true
+
+  assert_equal(
+    calls.sort,
+    @analyzer.calls.to_a.sort,
+    "assert_calls"
+  )
+end
+
+def assert_consts(*consts)
+  raise "Make sure assert_consts is called within the block passed to assert_phlex" if @analyzer.nil?
+
+  @assert_consts_called = true
+
+  assert_equal(
+    consts.sort,
+    @analyzer.consts.to_a.sort,
+    "assert_consts"
+  )
+end
+
+def assert_instance_methods(*instance_methods)
+  raise "Make sure assert_instance_methods is called within the block passed to assert_phlex" if @analyzer.nil?
+
+  @assert_instance_methods_called = true
+
+  assert_equal(
+    instance_methods.sort,
+    @analyzer.instance_methods.to_a.sort,
+    "assert_instance_methods"
   )
 end


### PR DESCRIPTION
This pull request enhances `Phlexing::RubyAnalyzer` to also detect `const`, `calls` and `instance_methods`.

Detecting `instance_methods` could to be useful if we want to include certain modules based on the methods used in the template. For example we could detect Rails helpers this way and include the appropriate ones in the generated code.

Detecting `consts` within the template could be useful down the road if we are dealing with the rendering of other components in the template and if we want to do some checks around it.

I'm not sure yet what we could do with the `calls`, but I think it might be useful to have in any case.