### PR TITLE
Only output parens in ERB attribute if needed

### DIFF
--- a/gem/lib/phlexing/template_generator.rb
+++ b/gem/lib/phlexing/template_generator.rb
@@ -83,7 +83,8 @@ module Phlexing
         s << arg(attribute.name.delete_prefix("data-erb-").underscore)
 
         s << if attribute.value.start_with?("<%=")
-          parens(unwrap_erb(attribute.value))
+          value = unwrap_erb(attribute.value)
+          value.include?(" ") ? parens(value) : value
         else
           quote("FIXME: #{unwrap_erb(attribute.value)}")
         end

--- a/gem/test/phlexing/converter/attributes_test.rb
+++ b/gem/test/phlexing/converter/attributes_test.rb
@@ -9,7 +9,7 @@ class Phlexing::Converter::AttributesTest < Minitest::Spec
     HTML
 
     expected = <<~PHLEX.strip
-      div(class: (classes_helper)) { "Text" }
+      div(class: classes_helper) { "Text" }
     PHLEX
 
     assert_phlex_template expected, html
@@ -22,7 +22,7 @@ class Phlexing::Converter::AttributesTest < Minitest::Spec
 
     expected = <<~PHLEX.strip
       div(
-        class: (classes_helper),
+        class: classes_helper,
         style: (true? ? "background: red" : "background: blue")
       ) { "Text" }
     PHLEX


### PR DESCRIPTION
This pull request tweaks the output of parenthesis in interpolated ERB attributes to only output them if they are needed:

**Input:**
```erb
<div class="<%= classes_helper %>" id="<%= many? ? "posts" : "post" %>"></div>
```

**Previous output:**
```ruby
div(class: (classes_helper), id: (many? ? "posts" : "post"))
```

**New Output:**
```ruby
div(class: classes_helper, id: (many? ? "posts" : "post"))
```