### PR TITLE
Support conversion of `<header>` tags

### DIFF
--- a/gem/lib/phlexing/parser.rb
+++ b/gem/lib/phlexing/parser.rb
@@ -12,9 +12,9 @@ module Phlexing
       # https://github.com/spree/deface/blob/6bf18df76715ee3eb3d0cd1b6eda822817ace91c/lib/deface/parser.rb#L105-L111
       #
 
-      html_tag = /<html.*?(?:(?!>)[\s\S])*>/i
+      html_tag = /<html(( .*?(?:(?!>)[\s\S])*>)|>)/i
       head_tag = /<head(( .*?(?:(?!>)[\s\S])*>)|>)/i
-      body_tag = /<body.*?(?:(?!>)[\s\S])*>/i
+      body_tag = /<body(( .*?(?:(?!>)[\s\S])*>)|>)/i
 
       if source =~ html_tag
         Nokogiri::HTML::Document.parse(source)

--- a/gem/lib/phlexing/parser.rb
+++ b/gem/lib/phlexing/parser.rb
@@ -13,7 +13,7 @@ module Phlexing
       #
 
       html_tag = /<html.*?(?:(?!>)[\s\S])*>/i
-      head_tag = /<head.*?(?:(?!>)[\s\S])*>/i
+      head_tag = /<head(( .*?(?:(?!>)[\s\S])*>)|>)/i
       body_tag = /<body.*?(?:(?!>)[\s\S])*>/i
 
       if source =~ html_tag

--- a/gem/test/phlexing/converter/tags_test.rb
+++ b/gem/test/phlexing/converter/tags_test.rb
@@ -10,6 +10,7 @@ class Phlexing::Converter::TagsTest < Minitest::Spec
     assert_phlex_template "template_tag", %(<template></template>)
     assert_phlex_template "html", %(<html></html>)
     assert_phlex_template "head", %(<head></head>)
+    assert_phlex_template "header", %(<header></header>)
     assert_phlex_template "body", %(<body></body>)
   end
 
@@ -171,6 +172,18 @@ class Phlexing::Converter::TagsTest < Minitest::Spec
     assert_phlex_template expected, html
   end
 
+  it "standlone head tag with attributes" do
+    html = <<~HTML.strip
+      <head id="123"></head>
+    HTML
+
+    expected = <<~PHLEX.strip
+      head(id: "123")
+    PHLEX
+
+    assert_phlex_template expected, html
+  end
+
   it "standlone body tag" do
     html = <<~HTML.strip
       <body></body>
@@ -178,6 +191,26 @@ class Phlexing::Converter::TagsTest < Minitest::Spec
 
     expected = <<~PHLEX.strip
       body
+    PHLEX
+
+    assert_phlex_template expected, html
+  end
+
+  it "should convert header tag" do
+    html = %(<header>Hello</header>)
+
+    expected = <<~PHLEX.strip
+      header { "Hello" }
+    PHLEX
+
+    assert_phlex_template expected, html
+  end
+
+  it "should convert header tag with attributes" do
+    html = %(<header id="123">Hello</header>)
+
+    expected = <<~PHLEX.strip
+      header(id: "123") { "Hello" }
     PHLEX
 
     assert_phlex_template expected, html


### PR DESCRIPTION
Fixes #73 

This works now:

**ERB Input:**
```erb
<header>Hello</header>
```

**Output:**
```ruby
class HeaderComponent < Phlex::HTML
  def template
    header { "Hello" }
  end
end
```
