### PR TITLE
Provide comment output as a block

### DIFF
--- a/gem/lib/phlexing/helpers.rb
+++ b/gem/lib/phlexing/helpers.rb
@@ -30,6 +30,10 @@ module Phlexing
       "(#{string})"
     end
 
+    def braces(string)
+      "{ #{string} }"
+    end
+
     def interpolate(string)
       "\#\{#{string}\}"
     end

--- a/gem/lib/phlexing/template_generator.rb
+++ b/gem/lib/phlexing/template_generator.rb
@@ -34,7 +34,7 @@ module Phlexing
     end
 
     def handle_html_comment_output(text)
-      output("comment", quote(text))
+      output("comment", braces(quote(text)))
     end
 
     def handle_erb_comment_output(text)

--- a/gem/test/phlexing/converter/comments_test.rb
+++ b/gem/test/phlexing/converter/comments_test.rb
@@ -10,7 +10,7 @@ class Phlexing::Converter::CommentsTest < Minitest::Spec
     HTML
 
     expected = <<~PHLEX.strip
-      comment "Hello Comment"
+      comment { "Hello Comment" }
       div { "Hello World" }
     PHLEX
 
@@ -24,7 +24,7 @@ class Phlexing::Converter::CommentsTest < Minitest::Spec
     HTML
 
     expected = <<~PHLEX.strip
-      comment "Hello 'Comment'"
+      comment { "Hello 'Comment'" }
       div { "Hello World" }
     PHLEX
 
@@ -38,7 +38,7 @@ class Phlexing::Converter::CommentsTest < Minitest::Spec
     HTML
 
     expected = <<~PHLEX.strip
-      comment %(Hello "Comment")
+      comment { %(Hello "Comment") }
       div { "Hello World" }
     PHLEX
 
@@ -52,7 +52,7 @@ class Phlexing::Converter::CommentsTest < Minitest::Spec
     HTML
 
     expected = <<~PHLEX.strip
-      comment %(Hello 'Comment")
+      comment { %(Hello 'Comment") }
       div { "Hello World" }
     PHLEX
 


### PR DESCRIPTION
👋 I'm new to this code base, but I think this is the correct fix.

The current output is providing the comment body as a string argument to `comment`, but it should be provided in a block.

### Actual
<img width="1399" alt="CleanShot 2023-02-15 at 12 41 35@2x" src="https://user-images.githubusercontent.com/77887/219122770-07d91e4b-00e9-4429-a55b-463b224fa161.png">

### Desired
```ruby
comment { "Phlex" }
```

And thanks for all your work on Phlexing, it's been a big help!
