### PR TITLE
Generate empty instance methods in component

### DIFF
--- a/gem/lib/phlexing/component_generator.rb
+++ b/gem/lib/phlexing/component_generator.rb
@@ -68,6 +68,29 @@ module Phlexing
       out << converter.template_code
       out << newline
       out << "end"
+
+      if analyzer.instance_methods.any?
+        out << newline
+        out << newline
+        out << "private"
+        out << newline
+        out << newline
+
+        analyzer.instance_methods.sort.each do |instance_method|
+          out << "def "
+          out << instance_method
+          out << "(*args, **kwargs)"
+          out << newline
+          out << "# TODO: Implement me"
+          out << newline
+          out << "end"
+          out << newline
+          out << newline
+        end
+
+        out << newline
+      end
+
       out << newline
       out << "end"
       out << newline

--- a/gem/test/phlexing/converter_test.rb
+++ b/gem/test/phlexing/converter_test.rb
@@ -179,11 +179,56 @@ class Phlexing::ConverterTest < Minitest::Spec
         def template
           div(class: (some_helper(with: :args)))
         end
+
+        private
+
+        def some_helper(*args, **kwargs)
+          # TODO: Implement me
+        end
       end
     PHLEX
 
     assert_phlex expected, html do
       assert_instance_methods "some_helper"
+    end
+  end
+
+  it "should render private instance methods" do
+    html = %(<% if should_show? %><%= pretty_print(@user) %><%= another_helper(1) %><% end %>)
+
+    expected = <<~PHLEX.strip
+      class Component < Phlex::HTML
+        def initialize(user:)
+          @user = user
+        end
+
+        def template
+          if should_show?
+            text pretty_print(@user)
+
+            text another_helper(1)
+          end
+        end
+
+        private
+
+        def another_helper(*args, **kwargs)
+          # TODO: Implement me
+        end
+
+        def pretty_print(*args, **kwargs)
+          # TODO: Implement me
+        end
+
+        def should_show?(*args, **kwargs)
+          # TODO: Implement me
+        end
+      end
+    PHLEX
+
+    assert_phlex expected, html do
+      assert_ivars "user"
+      assert_instance_methods "another_helper", "pretty_print", "should_show?"
     end
   end
 


### PR DESCRIPTION
Phlexing's `RubyAnalyzer` has been detecting `instance_methods` for a while now, but we haven't done anything with them.

This pull request renders out the `instance_methods` as empty private methods inside the component so that the user knows that they need to implement them or provide them otherwise.

![Screenshot 2023-03-04 at 13 08 22](https://user-images.githubusercontent.com/6411752/222900269-c0e5a9db-f06c-4d79-a87b-ab97c7966e11.png)
