### PR TITLE
Fix typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![Tests](https://github.com/marcoroth/phlexing/actions/workflows/tests.yml/badge.svg)](https://github.com/marcoroth/phlexing/actions/workflows/tests.yml)
 [![Rubocop](https://github.com/marcoroth/phlexing/actions/workflows/rubocop.yml/badge.svg)](https://github.com/marcoroth/phlexing/actions/workflows/rubocop.yml)
 
-A simple ERB to [Phlex](https://github.com/marcoroth/phlexing) Converter.
+A simple ERB to [Phlex](https://www.phlex.fun) Converter.
 
 <a href="https://phlexing.fun">
   <img src="./screenshot.png" alt="Phlexing Screenshot">


### PR DESCRIPTION
The link to Phlex was actually linking back here.
I changed it link to the Phlex homepage, which seems more useful, to me, than the Phlex repo. Feel free to link wherever you want. :smiley_cat: