### PR TITLE
Handling boolean attributes properly

### DIFF
--- a/gem/lib/phlexing/template_generator.rb
+++ b/gem/lib/phlexing/template_generator.rb
@@ -54,7 +54,7 @@ module Phlexing
 
       attributes = []
 
-      node.attributes.each_value do |attribute|
+      node.attribute_nodes.each do |attribute|
         attributes << handle_attribute(attribute)
       end
 
@@ -74,7 +74,13 @@ module Phlexing
     def handle_html_attribute_output(attribute)
       String.new.tap { |s|
         s << arg(attribute.name.underscore)
-        s << quote(attribute.value)
+        if attribute.value.blank? && !attribute.to_html.include?("=")
+          # handling boolean attributes
+          # eg. <input required> => input(required: true)
+          s << "true"
+        else
+          s << quote(attribute.value)
+        end
       }
     end
 

--- a/gem/test/phlexing/converter/tags_test.rb
+++ b/gem/test/phlexing/converter/tags_test.rb
@@ -215,4 +215,24 @@ class Phlexing::Converter::TagsTest < Minitest::Spec
 
     assert_phlex_template expected, html
   end
+
+  it "should convert boolean attributes properly" do
+    html = %(<input required>)
+
+    expected = <<~PHLEX.strip
+      input(required: true)
+    PHLEX
+
+    assert_phlex_template expected, html
+  end
+
+  it "should convert blank attributes properly" do
+    html = %(<input required="">)
+
+    expected = <<~PHLEX.strip
+      input(required: "")
+    PHLEX
+
+    assert_phlex_template expected, html
+  end
 end


### PR DESCRIPTION
Closes #119. 

Nokogiri #value is always returning "" to <input required> and <input required="">, so I have to call `#to_html` and check if the `=` character is present. I'm not sure if this is the best way, but I tried a lot of Nokogiri methods and none of them returns `nil`.