### PR TITLE
Add logic to properly handle `Phlex::SVG`

### DIFF
--- a/gem/lib/phlexing/helpers.rb
+++ b/gem/lib/phlexing/helpers.rb
@@ -9,6 +9,8 @@ module Phlexing
       Phlex::HTML::VoidElements.registered_elements.values +
       Phlex::HTML::StandardElements.registered_elements.values
 
+    SVG_ELEMENTS = Phlex::SVG::StandardElements.registered_elements.values.map { |element| [element.downcase, element] }.to_h
+
     def whitespace
       options.whitespace? ? "whitespace\n" : ""
     end

--- a/gem/lib/phlexing/helpers.rb
+++ b/gem/lib/phlexing/helpers.rb
@@ -59,17 +59,27 @@ module Phlexing
     end
 
     def tag_name(node)
-      return "template_tag" if node.name == "template-tag"
-
       name = node.name.tr("-", "_")
 
-      @converter.custom_elements << name unless KNOWN_ELEMENTS.include?(name)
+      return name if name == "template_tag"
+      return name if name.start_with?("s.")
+      return name if KNOWN_ELEMENTS.include?(name)
+
+      @converter.custom_elements << name
 
       name
     end
 
-    def block
+    def block(params = nil)
       out << " {"
+
+      if params
+        out << " "
+        out << "|"
+        out << params
+        out << "|"
+      end
+
       yield
       out << " }"
     end

--- a/gem/lib/phlexing/helpers.rb
+++ b/gem/lib/phlexing/helpers.rb
@@ -9,7 +9,7 @@ module Phlexing
       Phlex::HTML::VoidElements.registered_elements.values +
       Phlex::HTML::StandardElements.registered_elements.values
 
-    SVG_ELEMENTS = Phlex::SVG::StandardElements.registered_elements.values.map { |element| [element.downcase, element] }.to_h
+    SVG_ELEMENTS = Phlex::SVG::StandardElements.registered_elements.values.to_h { |element| [element.downcase, element] }
 
     def whitespace
       options.whitespace? ? "whitespace\n" : ""

--- a/gem/lib/phlexing/options.rb
+++ b/gem/lib/phlexing/options.rb
@@ -2,16 +2,17 @@
 
 module Phlexing
   class Options
-    attr_accessor :component, :component_name, :parent_component, :whitespace
+    attr_accessor :component, :component_name, :parent_component, :whitespace, :svg_param
 
     alias_method :whitespace?, :whitespace
     alias_method :component?, :component
 
-    def initialize(component: false, component_name: "Component", parent_component: "Phlex::HTML", whitespace: true)
+    def initialize(component: false, component_name: "Component", parent_component: "Phlex::HTML", whitespace: true, svg_param: "s")
       @component = component
       @component_name = safe_constant_name(component_name)
       @parent_component = safe_constant_name(parent_component)
       @whitespace = whitespace
+      @svg_param = svg_param
     end
 
     def safe_constant_name(name)

--- a/gem/lib/phlexing/template_generator.rb
+++ b/gem/lib/phlexing/template_generator.rb
@@ -194,7 +194,7 @@ module Phlexing
     def handle_svg_node(node, level)
       node.children.each do |child|
         child.traverse do |subchild|
-          subchild.name = SVG_ELEMENTS[subchild.name] if SVG_ELEMENTS.has_key?(subchild.name)
+          subchild.name = SVG_ELEMENTS[subchild.name] if SVG_ELEMENTS.key?(subchild.name)
           subchild.name = subchild.name.prepend("#{options.svg_param}.") # rubocop:disable Style/RedundantSelfAssignment
         end
       end

--- a/gem/lib/phlexing/template_generator.rb
+++ b/gem/lib/phlexing/template_generator.rb
@@ -194,6 +194,7 @@ module Phlexing
     def handle_svg_node(node, level)
       node.children.each do |child|
         child.traverse do |subchild|
+          subchild.name = SVG_ELEMENTS[subchild.name] if SVG_ELEMENTS.has_key?(subchild.name)
           subchild.name = subchild.name.prepend("#{options.svg_param}.") # rubocop:disable Style/RedundantSelfAssignment
         end
       end

--- a/gem/test/phlexing/converter/svg_test.rb
+++ b/gem/test/phlexing/converter/svg_test.rb
@@ -48,7 +48,7 @@ class Phlexing::Converter::SvgTest < Minitest::Spec
     end
   end
 
-  xit "converts SVG with case-sensitive" do
+  it "converts SVG with case-sensitive" do
     html = %(
       <svg>
         <feSpecularLighting>

--- a/gem/test/phlexing/converter/svg_test.rb
+++ b/gem/test/phlexing/converter/svg_test.rb
@@ -1,0 +1,115 @@
+# frozen_string_literal: true
+
+require_relative "../../test_helper"
+
+class Phlexing::Converter::SvgTest < Minitest::Spec
+  it "converts SVG" do
+    html = %(
+      <svg>
+        <path d="123"></path>
+      </svg>
+    )
+
+    expected = <<~PHLEX.strip
+      svg { |s| s.path(d: "123") }
+    PHLEX
+
+    assert_phlex_template expected, html
+  end
+
+  it "converts SVG with attributes" do
+    html = %(
+      <svg one="attribute" two="attributes">
+        <path d="123"></path>
+      </svg>
+    )
+
+    expected = <<~PHLEX.strip
+      svg(one: "attribute", two: "attributes") { |s| s.path(d: "123") }
+    PHLEX
+
+    assert_phlex_template expected, html
+  end
+
+  it "converts SVG with ERB interpolation" do
+    html = %(
+      <svg one="<%= interpolate %>" two="<%= method_call(123) %>">
+        <path d="123"></path>
+      </svg>
+    )
+
+    expected = <<~PHLEX.strip
+      svg(one: interpolate, two: method_call(123)) { |s| s.path(d: "123") }
+    PHLEX
+
+    assert_phlex_template expected, html do
+      assert_locals "interpolate"
+      assert_instance_methods "method_call"
+    end
+  end
+
+  xit "converts SVG with case-sensitive" do
+    html = %(
+      <svg>
+        <feSpecularLighting>
+          <fePointLight/>
+        </feSpecularLighting>
+      </svg>
+    )
+
+    expected = <<~PHLEX.strip
+      svg { |s| s.feSpecularLighting { s.fePointLight } }
+    PHLEX
+
+    assert_phlex_template expected, html
+  end
+
+  it "nested SVG" do
+    html = %(
+      <svg xmlns="http://www.w3.org/2000/svg" version="1.1" width="5cm" height="5cm">
+        <desc>Two groups, each of two rectangles</desc>
+        <g id="group1" fill="red">
+          <rect x="1cm" y="1cm" width="1cm" height="1cm"/>
+          <rect x="3cm" y="1cm" width="1cm" height="1cm"/>
+        </g>
+
+        <g id="group2" fill="blue">
+          <rect x="1cm" y="3cm" width="1cm" height="1cm"/>
+          <rect x="3cm" y="3cm" width="1cm" height="1cm"/>
+        </g>
+
+        <rect x=".01cm" y=".01cm" width="4.98cm" height="4.98cm" fill="none" stroke="blue" stroke-width=".02cm"/>
+      </svg>
+    )
+
+    expected = <<~PHLEX.strip
+      svg(
+        xmlns: "http://www.w3.org/2000/svg",
+        version: "1.1",
+        width: "5cm",
+        height: "5cm"
+      ) do |s|
+        s.desc { "Two groups, each of two rectangles" }
+        s.g(id: "group1", fill: "red") do
+          s.rect(x: "1cm", y: "1cm", width: "1cm", height: "1cm")
+          s.rect(x: "3cm", y: "1cm", width: "1cm", height: "1cm")
+        end
+        s.g(id: "group2", fill: "blue") do
+          s.rect(x: "1cm", y: "3cm", width: "1cm", height: "1cm")
+          s.rect(x: "3cm", y: "3cm", width: "1cm", height: "1cm")
+        end
+        s.rect(
+          x: ".01cm",
+          y: ".01cm",
+          width: "4.98cm",
+          height: "4.98cm",
+          fill: "none",
+          stroke: "blue",
+          stroke_width: ".02cm"
+        )
+      end
+    PHLEX
+
+    assert_phlex_template expected, html
+  end
+end


### PR DESCRIPTION
This pull request adds logic to handle the `svg` method using the block syntax introduced via https://github.com/phlex-ruby/phlex/pull/493.

For example a document like:
```html
<svg>
  <path d="123"></path>
</svg>
```
now uses the a param for the `svg` block and now calls `path` on it:
```ruby
 svg { |s| s.path(d: "123") }
```

Resolves https://github.com/marcoroth/phlexing/issues/138