### PR TITLE
Add `template_name` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,17 @@ Phlexing::Converter.convert(%(<h1 class="title">Hello World</h1>))
 h1(class: "title") { "Hello World" }
 ```
 
+### Converter Options
+
+| Option | Type | Default Value | Description |
+| --- | --- | --- | --- |
+| `whitespace` | `Boolean` | `true` | Generate whitespace in and around HTML block elements. |
+| `component` | `Boolean` | `false` | Generate a Phlex class with a `view_template` method around your input. |
+| `component_name` | `String` | `"Component"` | The name of your Phlex class. |
+| `parent_component` | `String` | `"Phlex::HTML"` | The name of the parent class your Phlex class will inherit from. |
+| `svg_param` | `String` | `"s"` | The name of the block argument Phlex will use to generate SVG-specific elements. |
+| `template_name` | `String` | `"view_template"` | The name of the generated template method in your Phlex class. |
+
 ### Multi-line HTML
 
 ```ruby
@@ -77,7 +88,7 @@ class Component < Phlex::HTML
     @user = user
   end
 
-  def template
+  def view_template
     h1 { @user.name }
 
     p do
@@ -100,7 +111,7 @@ class Component < Phlex::HTML
   include Phlex::Rails::Helpers::LinkTo
   include Phlex::Rails::Helpers::Routes
 
-  def template
+  def view_template
     link_to "Home", root_path
   end
 end
@@ -115,7 +126,7 @@ Phlexing::Converter.convert(%(<% if active? %>Active<% else %>Inactive<% end %>)
 ##### Output
 ```ruby
 class Component < Phlex::HTML
-  def template
+  def view_template
     if active?
       text "Active"
     else

--- a/app/controllers/converters_controller.rb
+++ b/app/controllers/converters_controller.rb
@@ -8,6 +8,7 @@ class ConvertersController < ApplicationController
     source = params["input"] || ""
     whitespace = params["whitespace"] ? true : false
     component = params["component"] ? true : false
+    template_name = params["template_name"] ? "view_template" : "template"
 
     component_name = params["component_name"].presence || Phlexing::NameSuggestor.call(source)
     component_name = component_name.gsub(" ", "_").camelize
@@ -20,7 +21,8 @@ class ConvertersController < ApplicationController
       whitespace: whitespace,
       component: component,
       component_name: component_name,
-      parent_component: parent_component
+      parent_component: parent_component,
+      template_name: template_name
     )
   end
 end

--- a/app/lib/phlexing/renderer/phlex.rb
+++ b/app/lib/phlexing/renderer/phlex.rb
@@ -36,7 +36,7 @@ module Phlexing
 
             #{elements}
 
-            def template
+            def view_template
               #{template}
             end
 

--- a/app/views/converters/index.html.erb
+++ b/app/views/converters/index.html.erb
@@ -36,11 +36,21 @@
           <div data-controller="phlex-class">
             <div class="relative flex items-start mb-3">
               <div class="flex h-5 items-center">
+                <input checked id="template_name" name="template_name" type="checkbox" data-action="click->converter#submit" class="h-4 w-4 rounded border-gray-300 text-indigo-600 focus:ring-indigo-500">
+              </div>
+              <div class="ml-3 text-sm">
+                <label for="template_name" class="font-medium text-gray-700">Phlex View Template Name</label>
+                <p class="text-gray-500">Phlex 2.0 changed the view template name from <code class="bg-gray-100 py-0.5 px-1 rounded">template</code> to <code class="bg-gray-100 py-0.5 px-1 rounded">view_template</code>. Check this box to use the 2.0 syntax.</p>
+              </div>
+            </div>
+
+            <div class="relative flex items-start mb-3">
+              <div class="flex h-5 items-center">
                 <input checked id="component" name="component" type="checkbox" data-action="click->converter#submit click->phlex-class#toggle" class="h-4 w-4 rounded border-gray-300 text-indigo-600 focus:ring-indigo-500">
               </div>
               <div class="ml-3 text-sm">
                 <label for="component" class="font-medium text-gray-700">Generate Phlex class</label>
-                <p class="text-gray-500">Generate a Phlex class with a template method around your input</p>
+                <p class="text-gray-500">Generate a Phlex class with a <code class="bg-gray-100 py-0.5 px-1 rounded">view_template</code> method around your input</p>
               </div>
             </div>
 

--- a/gem/lib/phlexing/component_generator.rb
+++ b/gem/lib/phlexing/component_generator.rb
@@ -63,7 +63,7 @@ module Phlexing
         out << newline
       end
 
-      out << "def template"
+      out << "def #{options.template_name}"
       out << newline
       out << converter.template_code
       out << newline

--- a/gem/lib/phlexing/options.rb
+++ b/gem/lib/phlexing/options.rb
@@ -2,17 +2,18 @@
 
 module Phlexing
   class Options
-    attr_accessor :component, :component_name, :parent_component, :whitespace, :svg_param
+    attr_accessor :component, :component_name, :parent_component, :whitespace, :svg_param, :template_name
 
     alias_method :whitespace?, :whitespace
     alias_method :component?, :component
 
-    def initialize(component: false, component_name: "Component", parent_component: "Phlex::HTML", whitespace: true, svg_param: "s")
+    def initialize(component: false, component_name: "Component", parent_component: "Phlex::HTML", whitespace: true, svg_param: "s", template_name: "view_template")
       @component = component
       @component_name = safe_constant_name(component_name)
       @parent_component = safe_constant_name(parent_component)
       @whitespace = whitespace
       @svg_param = svg_param
+      @template_name = template_name
     end
 
     def safe_constant_name(name)

--- a/gem/test/phlexing/converter/custom_elements_test.rb
+++ b/gem/test/phlexing/converter/custom_elements_test.rb
@@ -47,7 +47,7 @@ class Phlexing::Converter::CustomElementsTest < Minitest::Spec
         register_element :another_custom
         register_element :my_custom
 
-        def template
+        def view_template
           my_custom do
             plain "Hello"
             another_custom { "World" }
@@ -76,7 +76,7 @@ class Phlexing::Converter::CustomElementsTest < Minitest::Spec
           @users = users
         end
 
-        def template
+        def view_template
           users.each do |user|
             d { user.firstname }
 

--- a/gem/test/phlexing/converter/rails_helpers_test.rb
+++ b/gem/test/phlexing/converter/rails_helpers_test.rb
@@ -387,7 +387,7 @@ class Phlexing::Converter::RailsHelpersTest < Minitest::Spec
       class Component < Phlex::HTML
         include Phlex::Rails::Helpers::Translate
 
-        def template
+        def view_template
           translate("hello")
         end
       end
@@ -406,7 +406,7 @@ class Phlexing::Converter::RailsHelpersTest < Minitest::Spec
         include Phlex::Rails::Helpers::T
         include Phlex::Rails::Helpers::Translate
 
-        def template
+        def view_template
           translate("hello")
 
           t("hello")

--- a/gem/test/phlexing/converter/template_name_test.rb
+++ b/gem/test/phlexing/converter/template_name_test.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+require_relative "../../test_helper"
+
+class Phlexing::Converter::TemplateNameTest < Minitest::Spec
+  it "defaults to 'view_template'" do
+    expected = <<~PHLEX.strip
+      class Component < Phlex::HTML
+        def view_template
+        end
+      end
+    PHLEX
+
+    assert_phlex expected, ""
+  end
+
+  it "accepts other value" do
+    expected = <<~PHLEX.strip
+      class Component < Phlex::HTML
+        def template
+        end
+      end
+    PHLEX
+
+    assert_phlex expected, "", template_name: "template"
+  end
+end

--- a/gem/test/phlexing/converter_test.rb
+++ b/gem/test/phlexing/converter_test.rb
@@ -26,7 +26,7 @@ class Phlexing::ConverterTest < Minitest::Spec
 
     expected = <<~PHLEX.strip
       class TestComponent < Phlex::HTML
-        def template
+        def view_template
           h1 { "Hello World" }
         end
       end
@@ -40,7 +40,7 @@ class Phlexing::ConverterTest < Minitest::Spec
 
     expected = <<~PHLEX.strip
       class Component < ApplicationView
-        def template
+        def view_template
           h1 { "Hello World" }
         end
       end
@@ -54,7 +54,7 @@ class Phlexing::ConverterTest < Minitest::Spec
 
     expected = <<~PHLEX.strip
       class TestComponent < ApplicationView
-        def template
+        def view_template
           h1 { "Hello World" }
         end
       end
@@ -73,7 +73,7 @@ class Phlexing::ConverterTest < Minitest::Spec
           @lastname = lastname
         end
 
-        def template
+        def view_template
           h1 do
             plain @firstname
             whitespace
@@ -110,7 +110,7 @@ class Phlexing::ConverterTest < Minitest::Spec
           @user = user
         end
 
-        def template
+        def view_template
           plain @user.name
 
           if show_company && @company
@@ -138,7 +138,7 @@ class Phlexing::ConverterTest < Minitest::Spec
           @classes = classes
         end
 
-        def template
+        def view_template
           div(class: @classes)
         end
       end
@@ -160,7 +160,7 @@ class Phlexing::ConverterTest < Minitest::Spec
           @classes = classes
         end
 
-        def template
+        def view_template
           div(class: classes)
         end
       end
@@ -176,7 +176,7 @@ class Phlexing::ConverterTest < Minitest::Spec
 
     expected = <<~PHLEX.strip
       class Component < Phlex::HTML
-        def template
+        def view_template
           div(class: (some_helper(with: :args)))
         end
 
@@ -202,7 +202,7 @@ class Phlexing::ConverterTest < Minitest::Spec
           @user = user
         end
 
-        def template
+        def view_template
           if should_show?
             plain pretty_print(@user)
 
@@ -245,7 +245,7 @@ class Phlexing::ConverterTest < Minitest::Spec
           @user = user
         end
 
-        def template
+        def view_template
           div(class: Router.user_path(user))
         end
       end


### PR DESCRIPTION
Phlex 2.0 is going to use the `view_template` method for defining templates. This change was started in https://github.com/phlex-ruby/phlex/pull/630 (tracked in https://github.com/phlex-ruby/phlex/issues/622)

This pull request allows to pass in a `template_name` option to the `Phlexing::Converter` class.

```ruby
irb(main)> puts Phlexing::Converter.convert("<h1>Hello World</h1>", component: true)

class Component < Phlex::HTML
  def view_template
    h1 { "Hello World" }
  end
end
```

```ruby
irb(main)> puts Phlexing::Converter.convert("<h1>Hello World</h1>", component: true, template_name: "template")

class Component < Phlex::HTML
  def template
    h1 { "Hello World" }
  end
end
```

Additionally, the online version also allows to toggle the 2.0 syntax:

![CleanShot 2024-01-30 at 21 30 25](https://github.com/marcoroth/phlexing/assets/6411752/7113da35-5b7e-486d-acf3-8d74a84541fe)

/cc @joeldrapper 

