### PR TITLE
Remove `#output-copy` element

### DIFF
--- a/app/javascript/controllers/converter_controller.js
+++ b/app/javascript/controllers/converter_controller.js
@@ -26,7 +26,7 @@ export default class extends Controller {
   }
 
   async copy(event) {
-    await navigator.clipboard.writeText(document.getElementById("output-copy").value)
+    await navigator.clipboard.writeText(document.getElementById("output").innerText)
 
     const button = (event.target instanceof HTMLButtonElement) ? event.target : event.target.closest("button")
 

--- a/app/views/converters/create.turbo_stream.erb
+++ b/app/views/converters/create.turbo_stream.erb
@@ -2,6 +2,5 @@
 <% lexer = Rouge::Lexers::Ruby.new %>
 
 <%= turbo_stream.update("output", formatter.format(lexer.lex(@converter.code))) %>
-<%= turbo_stream.update("output-copy", @converter.code) %>
 
 <%= turbo_stream.remove_css_class("#output", "bg-gray-100 animate-pulse duration-75") %>

--- a/app/views/converters/index.html.erb
+++ b/app/views/converters/index.html.erb
@@ -104,16 +104,15 @@
               <div class="-m-0.5 rounded-lg p-0.5" role="tabpanel" tabindex="0">
                 <div class="block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm">
                   <pre class="phlex-output p-3 mb-3 rounded overflow-auto font-mono bg-[#282c34] text-[#dcdfe4] highlight h-[70vh] overflow-scroll" id="output"></pre>
-                  <textarea id="output-copy" class="phlex-output hidden"></textarea
-                  </div>
                 </div>
               </div>
             </div>
           </div>
         </div>
-      </main>
-    </form>
-  </section>
+      </div>
+    </main>
+  </form>
+</section>
 
 <style type="text/css">
   <%= Rouge::Themes::Monokai.render(scope: 'pre') %>


### PR DESCRIPTION
Resolves https://github.com/marcoroth/phlexing/issues/326

I couldn't reproduce the behavior explained in #326, but the duplicate element just for being able to copy the content to the clipboard is not necessary.