### PR TITLE
Allow hot-reloading phlexing gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -45,7 +45,15 @@ gem "cssbundling-rails"
 # gem "bcrypt", "~> 3.1.7"
 
 # Simple ERB to Phlex converter
-gem "phlexing", path: "gem"
+# gem "phlexing", path: "gem"
+
+# dependencies of phlexing gem from gem/phlexing.gemspec
+gem "deface", "~> 1.9"
+gem "html_press", "~> 0.8.2"
+gem "syntax_tree", "~> 6.0"
+gem "phlex", "~> 1.6"
+gem "phlex-rails", ">= 0.9", "< 2.0"
+# end of dependencies of phlexing gem
 
 # A pure Ruby code highlighter that is compatible with Pygments
 gem "rouge", "~> 4.3"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -14,17 +14,6 @@ GIT
       ruby-progressbar (~> 1.7)
       unicode-display_width (>= 1.4.0, < 3.0)
 
-PATH
-  remote: gem
-  specs:
-    phlexing (0.6.0)
-      deface (~> 1.9)
-      html_press (~> 0.8.2)
-      nokogiri (~> 1.0)
-      phlex (~> 1.6)
-      phlex-rails (>= 0.9, < 2.0)
-      syntax_tree (~> 6.0)
-
 GEM
   remote: https://rubygems.org/
   specs:
@@ -130,7 +119,7 @@ GEM
       rainbow (>= 2.1.0)
     drb (2.2.1)
     erubi (1.13.0)
-    execjs (2.8.1)
+    execjs (2.9.1)
     globalid (1.2.1)
       activesupport (>= 6.1)
     html_press (0.8.2)
@@ -184,11 +173,10 @@ GEM
     parser (3.3.4.0)
       ast (~> 2.4.1)
       racc
-    phlex (1.10.1)
-    phlex-rails (1.1.1)
-      phlex (~> 1.9)
+    phlex (1.10.3)
+    phlex-rails (1.2.1)
+      phlex (~> 1.10.0)
       railties (>= 6.1, < 8)
-      zeitwerk (~> 2.6)
     polyglot (0.3.5)
     prettier_print (1.2.1)
     psych (5.1.2)
@@ -297,9 +285,12 @@ DEPENDENCIES
   bootsnap
   cssbundling-rails
   debug
+  deface (~> 1.9)
+  html_press (~> 0.8.2)
   irb (~> 1.14)
   jsbundling-rails
-  phlexing!
+  phlex (~> 1.6)
+  phlex-rails (>= 0.9, < 2.0)
   puma (~> 6.4)
   rack-rewrite (~> 1.5)
   rails (~> 7.1.4)
@@ -307,6 +298,7 @@ DEPENDENCIES
   rubocop!
   sprockets-rails
   stimulus-rails
+  syntax_tree (~> 6.0)
   turbo-rails (~> 2.0)
   turbo_power (~> 0.6)
   tzinfo-data

--- a/config/application.rb
+++ b/config/application.rb
@@ -23,7 +23,7 @@ require "action_cable/engine"
 # you've limited to :test, :development, or :production.
 Bundler.require(*Rails.groups)
 
-module Phlexing
+module PhlexingApp
   class Application < Rails::Application
     # Initialize configuration defaults for originally generated Rails version.
     config.load_defaults 7.1
@@ -32,6 +32,9 @@ module Phlexing
     # not contain `.rb` files, or that should not be reloaded or eager loaded.
     # Common ones are `templates`, `generators`, or `middleware`, for example.
     config.autoload_lib(ignore: %w(assets tasks))
+
+    # Instead of depending on the phlexing gem, add it to the autoload paths to enable hot reloading
+    config.autoload_paths << Rails.root.join("gem/lib")
 
     # Configuration for the application, engines, and railties goes here.
     #


### PR DESCRIPTION
When prototyping for #405 I wanted the phlexing gem to be hot reloaded. I think this is valuable for any future development of this app.

I needed to rename the Rails App's main module to PhlexingApp because the existence of the `Phlexing` constant prevented the files from the embedded gem to be loaded at all. I didn't need to change the module names in app/lib/phlexing/renderer, but feel free to change those as well, if you see it fit.